### PR TITLE
SVG - update generate to return JSX.Element

### DIFF
--- a/src/lib/icons/Seam.tsx
+++ b/src/lib/icons/Seam.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode, SVGProps } from 'react'
-export const SeamIcon = (props: SVGProps<SVGSVGElement>): ReactNode => (
+import type { SVGProps } from 'react'
+export const SeamIcon = (props: SVGProps<SVGSVGElement>): JSX.Element => (
   <svg
     xmlns='http://www.w3.org/2000/svg'
     width={167}

--- a/svgr.config.cjs
+++ b/svgr.config.cjs
@@ -7,13 +7,13 @@ module.exports = {
   expandProps: 'none',
   template: (variables, { tpl }) => {
     return tpl`
-import type { ReactNode, SVGProps } from 'react'
+import type { SVGProps } from 'react'
 
 ${variables.interfaces};
 
 export const ${variables.componentName.replace('Svg', '') + 'Icon'} = (${
       variables.props
-    }): ReactNode => (
+    }): JSX.Element => (
   ${variables.jsx}
 );
 `


### PR DESCRIPTION
Currenly returning `ReactNode` which isn't a valid react element for function components. This PR updates the return type to `JSX.Element`

TS error:

<img width="573" alt="CleanShot 2023-05-03 at 12 05 17@2x" src="https://user-images.githubusercontent.com/11449462/235825935-4329246f-50e5-42cc-a854-596926d4e72f.png">

Reference: https://stackoverflow.com/questions/58123398/when-to-use-jsx-element-vs-reactnode-vs-reactelement/72353143#72353143

