### PR TITLE
Storybook - add auto-docs for all components to show code examples

### DIFF
--- a/src/lib/ui/AccessCodeTable/AccessCodeTable.stories.tsx
+++ b/src/lib/ui/AccessCodeTable/AccessCodeTable.stories.tsx
@@ -1,9 +1,75 @@
-import { Dialog } from '@mui/material'
+import { Button, Dialog } from '@mui/material'
 import type { Meta, StoryObj } from '@storybook/react'
 import { DateTime } from 'luxon'
+import type { AccessCode } from 'seamapi'
 import { v4 as uuid } from 'uuid'
 
-import { AccessCodeTable } from 'lib/ui/AccessCodeTable/AccessCodeTable.js'
+import {
+  AccessCodeTable,
+  type AccessCodeTableProps,
+} from 'lib/ui/AccessCodeTable/AccessCodeTable.js'
+import useToggle from 'lib/use-toggle.js'
+
+const accessCodes: AccessCode[] = [
+  {
+    access_code_id: uuid(),
+    type: 'time_bound',
+    code: '1234',
+    created_at: Date.now().toString(),
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Guest - Gonzalez',
+    starts_at: DateTime.now().minus({ day: 2 }).toISO() ?? '',
+    ends_at: DateTime.now().plus({ day: 2 }).toISO() ?? '',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'time_bound',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Guest - Thompson',
+    starts_at: DateTime.now().plus({ day: 1 }).toISO() ?? '',
+    ends_at: DateTime.now().plus({ day: 3 }).toISO() ?? '',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'ongoing',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Guest - Kranz',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'ongoing',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Sparkle Cleaners',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'ongoing',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Guest - yang',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'ongoing',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Astro Plumbing',
+  },
+]
 
 /**
  * These stories showcase the device manager.
@@ -11,67 +77,9 @@ import { AccessCodeTable } from 'lib/ui/AccessCodeTable/AccessCodeTable.js'
 const meta: Meta<typeof AccessCodeTable> = {
   title: 'Example/AccessCodeTable',
   component: AccessCodeTable,
+  tags: ['autodocs'],
   args: {
-    accessCodes: [
-      {
-        access_code_id: uuid(),
-        type: 'time_bound',
-        code: '1234',
-        created_at: Date.now().toString(),
-        device_id: 'some_device_id',
-        status: 'set',
-        name: 'Guest - Gonzalez',
-        starts_at: DateTime.now().minus({ day: 2 }).toISO() ?? '',
-        ends_at: DateTime.now().plus({ day: 2 }).toISO() ?? '',
-      },
-      {
-        access_code_id: uuid(),
-        type: 'time_bound',
-        code: '1234',
-        created_at: DateTime.now().toISO() ?? '',
-        device_id: 'some_device_id',
-        status: 'set',
-        name: 'Guest - Thompson',
-        starts_at: DateTime.now().plus({ day: 1 }).toISO() ?? '',
-        ends_at: DateTime.now().plus({ day: 3 }).toISO() ?? '',
-      },
-      {
-        access_code_id: uuid(),
-        type: 'ongoing',
-        code: '1234',
-        created_at: DateTime.now().toISO() ?? '',
-        device_id: 'some_device_id',
-        status: 'set',
-        name: 'Guest - Kranz',
-      },
-      {
-        access_code_id: uuid(),
-        type: 'ongoing',
-        code: '1234',
-        created_at: DateTime.now().toISO() ?? '',
-        device_id: 'some_device_id',
-        status: 'set',
-        name: 'Sparkle Cleaners',
-      },
-      {
-        access_code_id: uuid(),
-        type: 'ongoing',
-        code: '1234',
-        created_at: DateTime.now().toISO() ?? '',
-        device_id: 'some_device_id',
-        status: 'set',
-        name: 'Guest - yang',
-      },
-      {
-        access_code_id: uuid(),
-        type: 'ongoing',
-        code: '1234',
-        created_at: DateTime.now().toISO() ?? '',
-        device_id: 'some_device_id',
-        status: 'set',
-        name: 'Astro Plumbing',
-      },
-    ],
+    accessCodes,
   },
 }
 
@@ -82,16 +90,22 @@ type Story = StoryObj<typeof AccessCodeTable>
 export const Content: Story = {}
 
 export const InsideModal: Story = {
-  render: (props) => {
-    // Wrap modal/dialog contents in `seam-components` class
-    // to apply styles when rendered in a portal,
-    // which is the default MUI behavior.
-    return (
-      <Dialog open fullWidth maxWidth='sm'>
+  render: InsideModalComponent,
+}
+
+function InsideModalComponent(props: AccessCodeTableProps) {
+  const [showing, toggleShowing] = useToggle()
+  // Wrap modal/dialog contents in `seam-components` class
+  // to apply styles when rendered in a portal,
+  // which is the default MUI behavior.
+  return (
+    <>
+      <Button onClick={toggleShowing}>Show Modal</Button>
+      <Dialog open={showing} fullWidth maxWidth='sm' onClose={toggleShowing}>
         <div className='seam-components'>
           <AccessCodeTable {...props} />
         </div>
       </Dialog>
-    )
-  },
+    </>
+  )
 }

--- a/src/lib/ui/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/ui/AccessCodeTable/AccessCodeTable.tsx
@@ -14,10 +14,12 @@ import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
 import { Caption } from 'lib/ui/typography/Caption.js'
 import { Title } from 'lib/ui/typography/Title.js'
 
-export function AccessCodeTable(props: {
+export interface AccessCodeTableProps {
   accessCodes: AccessCode[]
   onClickBack?: () => void
-}): JSX.Element {
+}
+
+export function AccessCodeTable(props: AccessCodeTableProps): JSX.Element {
   const { accessCodes, onClickBack } = props
 
   return (

--- a/src/lib/ui/DeviceDetails/DeviceDetails.stories.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.stories.tsx
@@ -4,7 +4,11 @@ import type { Meta, StoryObj } from '@storybook/react'
 import type { LockDevice } from 'seamapi'
 import { v4 as uuid } from 'uuid'
 
-import { DeviceDetails } from 'lib/ui/DeviceDetails/DeviceDetails.js'
+import {
+  DeviceDetails,
+  type DeviceDetailsProps,
+} from 'lib/ui/DeviceDetails/DeviceDetails.js'
+import useToggle from 'lib/use-toggle.js'
 
 const fakeDevice: LockDevice = {
   workspace_id: uuid(),
@@ -38,6 +42,7 @@ const meta: Meta<typeof DeviceDetails> = {
   args: {
     device: fakeDevice,
   },
+  tags: ['autodocs'],
 }
 
 export default meta
@@ -47,12 +52,18 @@ type Story = StoryObj<typeof DeviceDetails>
 export const Content: Story = {}
 
 export const InsideModal: Story = {
-  render: (props) => {
-    // Wrap modal/dialog contents in `seam-components` class
-    // to apply styles when rendered in a portal,
-    // which is the default MUI behavior.
-    return (
-      <Dialog open fullWidth maxWidth='sm'>
+  render: InsideModalComponent,
+}
+
+function InsideModalComponent(props: DeviceDetailsProps) {
+  const [showing, toggleShowing] = useToggle()
+  // Wrap modal/dialog contents in `seam-components` class
+  // to apply styles when rendered in a portal,
+  // which is the default MUI behavior.
+  return (
+    <>
+      <Button onClick={toggleShowing}>Show Modal</Button>
+      <Dialog open={showing} fullWidth maxWidth='sm' onClose={toggleShowing}>
         <IconButton
           sx={{
             position: 'absolute',
@@ -69,6 +80,6 @@ export const InsideModal: Story = {
           <Button variant='outlined'>Done</Button>
         </DialogActions>
       </Dialog>
-    )
-  },
+    </>
+  )
 }

--- a/src/lib/ui/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.tsx
@@ -9,7 +9,11 @@ import { OnlineStatus } from 'lib/ui/DeviceDetails/OnlineStatus.js'
 import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
 import useToggle from 'lib/use-toggle.js'
 
-export function DeviceDetails(props: { device: LockDevice }): JSX.Element {
+export interface DeviceDetailsProps {
+  device: LockDevice
+}
+
+export function DeviceDetails(props: DeviceDetailsProps): JSX.Element {
   const { device } = props
 
   const lockStatus = device.properties.locked ? t.locked : t.unlocked


### PR DESCRIPTION
Adds the `autodocs` tag which generates the docs page per component. The docs page has the ability to _show code_, and let's the user get a better understanding of how the component should be used in each case/story.

https://user-images.githubusercontent.com/11449462/236751533-6f016728-0900-4b09-99ff-76e8765e8900.mp4

