### PR TITLE
Add clientSessionToken prop to SeamProvider

### DIFF
--- a/src/lib/SeamProvider.tsx
+++ b/src/lib/SeamProvider.tsx
@@ -16,14 +16,14 @@ declare global {
 
 export interface SeamContext {
   client: Seam | null
-  clientOptions?: SeamClientOptions | undefined
+  clientOptions?: AllowedSeamClientOptions | undefined
   publishableKey?: string | undefined
   userIdentifierKey?: string | undefined
 }
 
 type SeamProviderProps =
   | SeamProviderPropsWithClient
-  | (SeamProviderPropsWithPublishableKey & SeamClientOptions)
+  | (SeamProviderPropsWithPublishableKey & AllowedSeamClientOptions)
 
 interface SeamProviderPropsWithClient {
   client: Seam
@@ -33,6 +33,8 @@ interface SeamProviderPropsWithPublishableKey {
   publishableKey: string
   userIdentifierKey?: string
 }
+
+type AllowedSeamClientOptions = Pick<SeamClientOptions, 'endpoint'>
 
 export function SeamProvider({
   children,
@@ -126,13 +128,19 @@ const isSeamProviderPropsWithClient = (
 
 const isSeamProviderPropsWithPublishableKey = (
   props: SeamProviderProps
-): props is SeamProviderPropsWithPublishableKey & SeamClientOptions => {
+): props is SeamProviderPropsWithPublishableKey & AllowedSeamClientOptions => {
   if ('publishableKey' in props) {
     const { publishableKey } = props
     if (publishableKey == null) return false
 
     if ('client' in props && props.client != null) {
       throw new Error('Cannot provide a Seam client along with other options.')
+    }
+
+    if ('clientSessionToken' in props && props.clientSessionToken != null) {
+      throw new Error(
+        'Cannot provide both a publishableKey and a clientSessionToken.'
+      )
     }
 
     return true

--- a/src/lib/seam/use-seam-client.ts
+++ b/src/lib/seam/use-seam-client.ts
@@ -10,18 +10,42 @@ export function useSeamClient(): {
   isError: boolean
   error: unknown
 } {
-  const { client, clientOptions, publishableKey, ...context } = useSeamContext()
+  const {
+    client,
+    clientOptions,
+    publishableKey,
+    clientSessionToken,
+    ...context
+  } = useSeamContext()
   const userIdentifierKey = useUserIdentifierKeyOrFingerprint(
-    context.userIdentifierKey
+    clientSessionToken ? '' : context.userIdentifierKey
   )
 
   const { isLoading, isError, error, data } = useQuery<Seam>({
-    queryKey: ['client', { client, userIdentifierKey }],
+    queryKey: [
+      'client',
+      {
+        client,
+        clientOptions,
+        publishableKey,
+        userIdentifierKey,
+        clientSessionToken,
+      },
+    ],
     queryFn: async () => {
       if (client != null) return client
 
+      if (clientSessionToken != null) {
+        return new Seam({
+          ...clientOptions,
+          clientSessionToken,
+        })
+      }
+
       if (publishableKey == null) {
-        throw new Error('Missing publishableKey')
+        throw new Error(
+          'Missing either a client, publishableKey, or clientSessionToken'
+        )
       }
 
       const res = await Seam.getClientSessionToken({


### PR DESCRIPTION
- refactor: Simplify SeamProviderProp parsing
- refactor: Use AllowedSeamClientOptions over SeamClientOptions
- feat: Add clientSessionToken to SeamProviderProps
- feat: Use clientSessionToken if passed to SeamProvider
