### PR TITLE
Fix access code table layout

### DIFF
--- a/src/lib/ui/AccessCodeTable/AccessCodeTable.stories.tsx
+++ b/src/lib/ui/AccessCodeTable/AccessCodeTable.stories.tsx
@@ -1,25 +1,91 @@
 import { Button, Dialog } from '@mui/material'
 import type { Meta, StoryObj } from '@storybook/react'
-import type { ComponentProps } from 'react'
+import { DateTime } from 'luxon'
+import type { AccessCode } from 'seamapi'
+import { v4 as uuid } from 'uuid'
 
-import { AccessCodeTable } from 'lib/ui/AccessCodeTable/AccessCodeTable.js'
+import {
+  AccessCodeTableContent,
+  type AccessCodeTableContentProps,
+} from 'lib/ui/AccessCodeTable/AccessCodeTableContent.js'
 import useToggle from 'lib/use-toggle.js'
+
+const accessCodes: AccessCode[] = [
+  {
+    access_code_id: uuid(),
+    type: 'time_bound',
+    code: '1234',
+    created_at: Date.now().toString(),
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Guest - Gonzalez',
+    starts_at: DateTime.now().minus({ day: 2 }).toISO() ?? '',
+    ends_at: DateTime.now().plus({ day: 2 }).toISO() ?? '',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'time_bound',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Guest - Thompson',
+    starts_at: DateTime.now().plus({ day: 1 }).toISO() ?? '',
+    ends_at: DateTime.now().plus({ day: 3 }).toISO() ?? '',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'ongoing',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Guest - Kranz',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'ongoing',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Sparkle Cleaners',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'ongoing',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Guest - yang',
+  },
+  {
+    access_code_id: uuid(),
+    type: 'ongoing',
+    code: '1234',
+    created_at: DateTime.now().toISO() ?? '',
+    device_id: 'some_device_id',
+    status: 'set',
+    name: 'Astro Plumbing',
+  },
+]
 
 /**
  * These stories showcase the device manager.
  */
-const meta: Meta<typeof AccessCodeTable> = {
+const meta: Meta<typeof AccessCodeTableContent> = {
   title: 'Example/AccessCodeTable',
-  component: AccessCodeTable,
+  component: AccessCodeTableContent,
   tags: ['autodocs'],
   args: {
-    deviceId: 'device1',
+    accessCodes,
   },
 }
 
 export default meta
 
-type Story = StoryObj<typeof AccessCodeTable>
+type Story = StoryObj<typeof AccessCodeTableContent>
 
 export const Content: Story = {}
 
@@ -27,7 +93,7 @@ export const InsideModal: Story = {
   render: InsideModalComponent,
 }
 
-function InsideModalComponent(props: ComponentProps<typeof AccessCodeTable>) {
+function InsideModalComponent(props: AccessCodeTableContentProps) {
   const [showing, toggleShowing] = useToggle()
   // Wrap modal/dialog contents in `seam-components` class
   // to apply styles when rendered in a portal,
@@ -37,7 +103,7 @@ function InsideModalComponent(props: ComponentProps<typeof AccessCodeTable>) {
       <Button onClick={toggleShowing}>Show Modal</Button>
       <Dialog open={showing} fullWidth maxWidth='sm' onClose={toggleShowing}>
         <div className='seam-components'>
-          <AccessCodeTable {...props} />
+          <AccessCodeTableContent {...props} />
         </div>
       </Dialog>
     </>

--- a/src/lib/ui/AccessCodeTable/AccessCodeTableContent.tsx
+++ b/src/lib/ui/AccessCodeTable/AccessCodeTableContent.tsx
@@ -1,0 +1,61 @@
+import type { AccessCode } from 'seamapi'
+
+import {
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+  TableTitle,
+} from 'lib/ui/Table/index.js'
+
+import { AccessCodeKeyIcon } from 'lib/icons/AccessCodeKey.js'
+import { CodeDetails } from 'lib/ui/AccessCodeTable/CodeDetails.js'
+import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
+import { Caption } from 'lib/ui/typography/Caption.js'
+import { Title } from 'lib/ui/typography/Title.js'
+
+export interface AccessCodeTableContentProps {
+  accessCodes: AccessCode[]
+  onClickBack?: () => void
+}
+
+export function AccessCodeTableContent(
+  props: AccessCodeTableContentProps
+): JSX.Element {
+  const { accessCodes, onClickBack } = props
+
+  return (
+    <div className='seam-access-code-table'>
+      <ContentHeader onClickBack={onClickBack} />
+      <TableHeader>
+        <TableTitle>
+          {t.accessCodes} <Caption>({accessCodes.length})</Caption>
+        </TableTitle>
+      </TableHeader>
+      <TableBody>
+        {accessCodes.map((code) => (
+          <TableRow key={code.access_code_id}>
+            <TableCell className='seam-icon-cell'>
+              <div>
+                <AccessCodeKeyIcon />
+              </div>
+            </TableCell>
+            <TableCell className='seam-name-cell'>
+              <Title>{code.name}</Title>
+              <CodeDetails accessCode={code} />
+            </TableCell>
+            <TableCell className='seam-action-cell'>
+              {/* <IconButton>
+                <DotsEllipsisMoreIcon />
+              </IconButton> */}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </div>
+  )
+}
+
+const t = {
+  accessCodes: 'Access Codes',
+}

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -5,7 +5,6 @@
     align-items: center;
     position: relative;
     justify-content: center;
-    width: 100%;
 
     .seam-back-icon {
       position: absolute;


### PR DESCRIPTION
Fixes #93 

Was due to `width: 100%` on the header component. Good to remove as any layout should use `flex` to avoid width issues because we're not sure what the parent component would be.

### Note on `AccessCodeTableContent`

After #80 was merged, we lost the ability to preview `AccessCodeTable` in storybook because without a fake it was trying to make real api calls.

As a temporary workaround, I've refactored out `AccessCodeTableContent` which is the UI for `AccessCodeTable`, without the data-binding. I've also updated the story to use `AccessCodeTableContent` for now until the fake client is ready.