### PR TITLE
Device Details - Fix incorrect spacing and missing CSS reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "storybook-addon-designs": "^7.0.0-beta.2",
         "stylelint": "^15.6.0",
         "stylelint-config-standard-scss": "^9.0.0",
-        "the-new-css-reset": "^1.8.4",
         "ts-jest": "^29.1.0",
         "tsc-alias": "^1.8.5",
         "tsconfig-paths-webpack-plugin": "^4.0.1",
@@ -21870,12 +21869,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
-    "node_modules/the-new-css-reset": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/the-new-css-reset/-/the-new-css-reset-1.8.4.tgz",
-      "integrity": "sha512-Upmb9XTyk78BmTbMQuAOTlESH9zmwqDAmmYC9MVm7uZLQdvGfxFTMhbpjKMUDwfmXGKnq6nkzISs/ReqHUP5xg==",
       "dev": true
     },
     "node_modules/through2": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,6 @@
     "storybook-addon-designs": "^7.0.0-beta.2",
     "stylelint": "^15.6.0",
     "stylelint-config-standard-scss": "^9.0.0",
-    "the-new-css-reset": "^1.8.4",
     "ts-jest": "^29.1.0",
     "tsc-alias": "^1.8.5",
     "tsconfig-paths-webpack-plugin": "^4.0.1",

--- a/src/lib/ui/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.tsx
@@ -41,8 +41,8 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element {
             <div className='seam-image'>
               <DeviceImage device={device} />
             </div>
-
             <div className='seam-info'>
+              <span className='seam-label'>{t.device}</span>
               <h4 className='seam-device-name'>{device.properties.name}</h4>
               <div className='seam-properties'>
                 <OnlineStatus device={device} />
@@ -93,6 +93,7 @@ function AccessCodeLength(props: {
 }
 
 const t = {
+  device: 'Device',
   locked: 'Locked',
   unlocked: 'Unlocked',
   accessCodes: 'access codes',

--- a/src/styles/_device-details.scss
+++ b/src/styles/_device-details.scss
@@ -67,7 +67,6 @@
           }
 
           .seam-info {
-
             > .seam-label {
               color: var(--text-gray-1);
               font-weight: 600;

--- a/src/styles/_device-details.scss
+++ b/src/styles/_device-details.scss
@@ -67,6 +67,15 @@
           }
 
           .seam-info {
+
+            > .seam-label {
+              color: var(--text-gray-1);
+              font-weight: 600;
+              font-size: 14px;
+              line-height: 134%;
+              margin-bottom: 4px;
+            }
+
             .seam-device-name {
               margin-bottom: 16px;
               font-weight: 600;

--- a/src/styles/_main.scss
+++ b/src/styles/_main.scss
@@ -1,3 +1,4 @@
+@use './reset';
 @use './typography';
 @use './tables';
 @use './inputs';
@@ -21,8 +22,7 @@
   --item-hover-bg: #f4f6f8;
 
   // Reset
-  /* stylelint-disable */
-  @import 'the-new-css-reset/css/reset.css';
+  @include reset.all;
 
   // Globals
   @include typography.all;

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -64,8 +64,8 @@
     margin: 0;
     padding: 0;
     border: 0;
-    font-family: inherit;
     font-size: 100%;
+    font-family: inherit;
     vertical-align: baseline;
     text-rendering: optimizelegibility;
     -webkit-font-smoothing: antialiased;

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -4,50 +4,111 @@
 */
 
 @mixin all {
-    *, *:before, *:after{
-      box-sizing: border-box;
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
   }
 
-  html, body, div, span, object, iframe, figure, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, code, em, img, small, strike, strong, sub, sup, tt, b, u, i, ol, ul, li, fieldset, form, label, table, caption, tbody, tfoot, thead, tr, th, td, main, canvas, embed, footer, header, nav, section, video{
-      margin: 0;
-      padding: 0;
-      border: 0;
-      font-size: 100%;
-      font: inherit;
-      vertical-align: baseline;
-      text-rendering: optimizeLegibility;
-      -webkit-font-smoothing: antialiased;
-      text-size-adjust: none;
+  html,
+  body,
+  div,
+  span,
+  object,
+  iframe,
+  figure,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  code,
+  em,
+  img,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  b,
+  u,
+  i,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  main,
+  canvas,
+  embed,
+  footer,
+  header,
+  nav,
+  section,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+    text-rendering: optimizelegibility;
+    -webkit-font-smoothing: antialiased;
+    text-size-adjust: none;
   }
 
-  footer, header, nav, section, main{
-      display: block;
+  footer,
+  header,
+  nav,
+  section,
+  main {
+    display: block;
   }
 
-  body{
-      line-height: 1;
+  body {
+    line-height: 1;
   }
 
-  ol, ul{
-      list-style: none;
+  ol,
+  ul {
+    list-style: none;
   }
 
-  blockquote, q{
-      quotes: none;
+  blockquote,
+  q {
+    quotes: none;
   }
 
-  blockquote:before, blockquote:after, q:before, q:after{
-      content: '';
-      content: none;
+  blockquote::before,
+  blockquote::after,
+  q::before,
+  q::after {
+    content: '';
+    content: none;
   }
 
-  table{
-      border-collapse: collapse;
-      border-spacing: 0;
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
   }
 
-  input{
-      -webkit-appearance: none;
-      border-radius: 0;
+  input {
+    appearance: none;
+    border-radius: 0;
   }
 }

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -64,8 +64,8 @@
     margin: 0;
     padding: 0;
     border: 0;
+    font-family: inherit;
     font-size: 100%;
-    font: inherit;
     vertical-align: baseline;
     text-rendering: optimizelegibility;
     -webkit-font-smoothing: antialiased;

--- a/src/styles/_reset.scss
+++ b/src/styles/_reset.scss
@@ -1,0 +1,53 @@
+/**
+* CSS Reset heavily inspired by Fraser Boag's reset.
+* Source: https://www.boag.online/blog/css-reset
+*/
+
+@mixin all {
+    *, *:before, *:after{
+      box-sizing: border-box;
+  }
+
+  html, body, div, span, object, iframe, figure, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, code, em, img, small, strike, strong, sub, sup, tt, b, u, i, ol, ul, li, fieldset, form, label, table, caption, tbody, tfoot, thead, tr, th, td, main, canvas, embed, footer, header, nav, section, video{
+      margin: 0;
+      padding: 0;
+      border: 0;
+      font-size: 100%;
+      font: inherit;
+      vertical-align: baseline;
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+      text-size-adjust: none;
+  }
+
+  footer, header, nav, section, main{
+      display: block;
+  }
+
+  body{
+      line-height: 1;
+  }
+
+  ol, ul{
+      list-style: none;
+  }
+
+  blockquote, q{
+      quotes: none;
+  }
+
+  blockquote:before, blockquote:after, q:before, q:after{
+      content: '';
+      content: none;
+  }
+
+  table{
+      border-collapse: collapse;
+      border-spacing: 0;
+  }
+
+  input{
+      -webkit-appearance: none;
+      border-radius: 0;
+  }
+}


### PR DESCRIPTION
Fixes #88
Fixes #82

Was due to the missing CSS reset.

- removed `the-new-css-reset`
- Added custom `./reset.scss` crediting [source](https://www.boag.online/blog/css-reset)
- Added 'Device' label above the name

### After

![image](https://user-images.githubusercontent.com/11449462/237006869-1aa7435c-6d5b-4bad-8eba-52b0428c4f99.png)
