### PR TITLE
ci: Limit semantic release branch triggers

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -6,7 +6,12 @@ run-name: Semantic Release from ${{ github.ref_name }}
 on:
   push:
     branches:
-      - '**'
+      - 'main'
+      - 'next'
+      - 'next-major'
+      - 'beta'
+      - 'alpha'
+      - '*.x'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}


### PR DESCRIPTION
Stops this check from showing up on PRs.