### PR TITLE
Navigation

### DIFF
--- a/src/lib/ui/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/ui/AccessCodeDetails/AccessCodeDetails.tsx
@@ -1,21 +1,38 @@
 import { DateTime } from 'luxon'
-import type { AccessCode } from 'seamapi'
+import { useState } from 'react'
+import type { AccessCode, CommonDeviceProperties, Device } from 'seamapi'
 
 import AccessCodeDevice from 'lib/ui/AccessCodeDetails/AccessCodeDevice.js'
+import { DeviceDetails } from 'lib/ui/DeviceDetails/DeviceDetails.js'
 import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
 
 export interface AccessCodeDetailsProps {
   accessCode: AccessCode
+  onBack?: () => void
 }
 
 export default function AccessCodeDetails({
   accessCode,
+  onBack,
 }: AccessCodeDetailsProps) {
   const name = accessCode.name ?? t.fallbackName
+  const [selectedDevice, selectDevice] =
+    useState<Device<CommonDeviceProperties> | null>(null)
+
+  if (selectedDevice) {
+    return (
+      <DeviceDetails
+        device={selectedDevice}
+        onBack={() => {
+          selectDevice(null)
+        }}
+      />
+    )
+  }
 
   return (
     <div className='seam-access-code-details'>
-      <ContentHeader title='Access code' />
+      <ContentHeader title='Access code' onBack={onBack} />
       <div className='seam-summary'>
         <div className='seam-top'>
           <span className='seam-label'>{t.accessCode}</span>
@@ -25,7 +42,10 @@ export default function AccessCodeDetails({
             <Duration accessCode={accessCode} />
           </div>
         </div>
-        <AccessCodeDevice deviceId={accessCode.device_id} />
+        <AccessCodeDevice
+          deviceId={accessCode.device_id}
+          onSelectDevice={selectDevice}
+        />
       </div>
       <div className='seam-details'>
         <div className='seam-row'>

--- a/src/lib/ui/AccessCodeDetails/AccessCodeDevice.tsx
+++ b/src/lib/ui/AccessCodeDetails/AccessCodeDevice.tsx
@@ -1,3 +1,5 @@
+import type { CommonDeviceProperties, Device } from 'seamapi'
+
 import { isLockDevice } from 'lib/seam/devices/types.js'
 import { useFakeDevice } from 'lib/seam/devices/use-device.js'
 import { Button } from 'lib/ui/Button.js'
@@ -5,7 +7,13 @@ import { DeviceImage } from 'lib/ui/device/DeviceImage.js'
 import { getDeviceModel } from 'lib/ui/DeviceDetails/DeviceModel.js'
 import { TextButton } from 'lib/ui/TextButton.js'
 
-export default function AccessCodeDevice({ deviceId }: { deviceId: string }) {
+export default function AccessCodeDevice({
+  deviceId,
+  onSelectDevice,
+}: {
+  deviceId: string
+  onSelectDevice: (device: Device<CommonDeviceProperties>) => void
+}) {
   //  TODO: Replace with `useDevice()` once ready
   const { isLoading, device } = useFakeDevice({ device_id: deviceId })
 
@@ -23,7 +31,13 @@ export default function AccessCodeDevice({ deviceId }: { deviceId: string }) {
       </div>
       <div className='seam-body'>
         <div className='seam-model'>{model}</div>
-        <TextButton>{t.deviceDetails}</TextButton>
+        <TextButton
+          onClick={() => {
+            onSelectDevice(device)
+          }}
+        >
+          {t.deviceDetails}
+        </TextButton>
       </div>
       <Button>Unlock</Button>
     </div>

--- a/src/lib/ui/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/ui/AccessCodeTable/AccessCodeTable.tsx
@@ -1,5 +1,9 @@
+import { useState } from 'react'
+import type { AccessCode } from 'seamapi'
+
 import { AccessCodeKeyIcon } from 'lib/icons/AccessCodeKey.js'
 import { useAccessCodes } from 'lib/seam/access-codes/use-access-codes.js'
+import AccessCodeDetails from 'lib/ui/AccessCodeDetails/AccessCodeDetails.js'
 import { CodeDetails } from 'lib/ui/AccessCodeTable/CodeDetails.js'
 import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
 import { TableBody } from 'lib/ui/Table/TableBody.js'
@@ -19,6 +23,21 @@ export function AccessCodeTable(props: {
   })
   const { onBack } = props
 
+  const [selectedAccessCode, selectAccessCode] = useState<AccessCode | null>(
+    null
+  )
+
+  if (selectedAccessCode) {
+    return (
+      <AccessCodeDetails
+        accessCode={selectAccessCode}
+        onBack={() => {
+          selectAccessCode(null)
+        }}
+      />
+    )
+  }
+
   if (!accessCodes) return <>{null}</>
 
   return (
@@ -31,7 +50,12 @@ export function AccessCodeTable(props: {
       </TableHeader>
       <TableBody>
         {accessCodes.map((code) => (
-          <TableRow key={code.access_code_id}>
+          <TableRow
+            key={code.access_code_id}
+            onClick={() => {
+              selectAccessCode(code)
+            }}
+          >
             <TableCell className='seam-icon-cell'>
               <div>
                 <AccessCodeKeyIcon />

--- a/src/lib/ui/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/ui/AccessCodeTable/AccessCodeTable.tsx
@@ -30,7 +30,7 @@ export function AccessCodeTable(props: {
   if (selectedAccessCode) {
     return (
       <AccessCodeDetails
-        accessCode={selectAccessCode}
+        accessCode={selectedAccessCode}
         onBack={() => {
           selectAccessCode(null)
         }}

--- a/src/lib/ui/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.tsx
@@ -1,6 +1,7 @@
-import { type LockDevice } from 'seamapi'
+import { type CommonDeviceProperties, type Device } from 'seamapi'
 
 import { ChevronRightIcon } from 'lib/icons/ChevronRight.js'
+import { isLockDevice } from 'lib/seam/devices/types.js'
 import { AccessCodeTable } from 'lib/ui/AccessCodeTable/AccessCodeTable.js'
 import { Button } from 'lib/ui/Button.js'
 import { BatteryStatus } from 'lib/ui/device/BatteryStatus.js'
@@ -11,16 +12,12 @@ import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
 import useToggle from 'lib/use-toggle.js'
 
 export interface DeviceDetailsProps {
-  device: LockDevice
+  device: Device<CommonDeviceProperties>
+  onBack?: () => void
 }
 
-export function DeviceDetails(props: DeviceDetailsProps): JSX.Element {
-  const { device } = props
-
-  const lockStatus = device.properties.locked ? t.locked : t.unlocked
-
-  const accessCodeLength =
-    device.properties?.schlage_metadata?.access_code_length
+export function DeviceDetails(props: DeviceDetailsProps): JSX.Element | null {
+  const { device, onBack } = props
 
   const [showingAccessCodes, toggleAccessCodes] = useToggle()
 
@@ -30,9 +27,18 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element {
     )
   }
 
+  if (!isLockDevice(device)) {
+    return null
+  }
+
+  const lockStatus = device.properties.locked ? t.locked : t.unlocked
+
+  const accessCodeLength =
+    device.properties?.schlage_metadata?.access_code_length
+
   return (
     <div className='seam-device-details'>
-      <ContentHeader title='Device' />
+      <ContentHeader title='Device' onBack={onBack} />
       <div className='seam-body'>
         <div className='seam-summary'>
           <div className='seam-content'>
@@ -57,7 +63,9 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element {
             className='seam-content seam-access-codes'
             onClick={toggleAccessCodes}
           >
-            <span className='seam-value'>49 {t.accessCodes}</span>
+            <span className='seam-value'>
+              {accessCodeLength} {t.accessCodes}
+            </span>
             <ChevronRightIcon />
           </div>
         </div>

--- a/src/lib/ui/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.tsx
@@ -1,5 +1,7 @@
 import { type CommonDeviceProperties, type Device } from 'seamapi'
 
+import { useAccessCodes } from 'lib/index.js'
+
 import { ChevronRightIcon } from 'lib/icons/ChevronRight.js'
 import { isLockDevice } from 'lib/seam/devices/types.js'
 import { AccessCodeTable } from 'lib/ui/AccessCodeTable/AccessCodeTable.js'
@@ -21,6 +23,14 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element | null {
 
   const [showingAccessCodes, toggleAccessCodes] = useToggle()
 
+  const { isLoading, accessCodes } = useAccessCodes({
+    device_id: device.device_id,
+  })
+
+  if (isLoading) {
+    return null
+  }
+
   if (showingAccessCodes) {
     return (
       <AccessCodeTable deviceId={device.device_id} onBack={toggleAccessCodes} />
@@ -32,6 +42,8 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element | null {
   }
 
   const lockStatus = device.properties.locked ? t.locked : t.unlocked
+
+  const accessCodeCount = accessCodes?.length
 
   const accessCodeLength =
     device.properties?.schlage_metadata?.access_code_length
@@ -64,7 +76,7 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element | null {
             onClick={toggleAccessCodes}
           >
             <span className='seam-value'>
-              {accessCodeLength} {t.accessCodes}
+              {accessCodeCount} {t.accessCodes}
             </span>
             <ChevronRightIcon />
           </div>

--- a/src/lib/ui/DeviceTable/DeviceTable.stories.tsx
+++ b/src/lib/ui/DeviceTable/DeviceTable.stories.tsx
@@ -17,13 +17,15 @@ export default meta
 
 type Story = StoryObj<typeof DeviceTable>
 
-export const Content: Story = {}
+export const Content: Story = {
+  render: ({ onBack, ...otherProps }) => <DeviceTable {...otherProps} />,
+}
 
 export const InsideModal: Story = {
   render: InsideModalComponent,
 }
 
-function InsideModalComponent(props: DeviceTableProps) {
+function InsideModalComponent({ onBack, ...otherProps }: DeviceTableProps) {
   const [open, toggleOpen] = useToggle()
   // Wrap modal/dialog contents in `seam-components` class
   // to apply styles when rendered in a portal,
@@ -33,7 +35,7 @@ function InsideModalComponent(props: DeviceTableProps) {
       <Button onClick={toggleOpen}>Open Modal</Button>
       <Dialog open={open} fullWidth maxWidth='sm' onClose={toggleOpen}>
         <div className='seam-components'>
-          <DeviceTable {...props} />
+          <DeviceTable {...otherProps} />
         </div>
         <DialogActions
           sx={{

--- a/src/lib/ui/DeviceTable/DeviceTable.tsx
+++ b/src/lib/ui/DeviceTable/DeviceTable.tsx
@@ -1,3 +1,8 @@
+import { useState } from 'react'
+import type { CommonDeviceProperties, Device } from 'seamapi'
+
+import { DeviceDetails } from 'lib/index.js'
+
 import { isLockDevice } from 'lib/seam/devices/types.js'
 import {
   useDevices,
@@ -27,6 +32,20 @@ interface Props {
 export function DeviceTable({ onBack, ...props }: DeviceTableProps) {
   const { devices, isLoading, isError, error } = useDevices(props)
 
+  const [selectedDevice, selectDevice] =
+    useState<Device<CommonDeviceProperties> | null>(null)
+
+  if (selectedDevice) {
+    return (
+      <DeviceDetails
+        device={selectedDevice}
+        onBack={() => {
+          selectDevice(null)
+        }}
+      />
+    )
+  }
+
   if (isLoading) return <p>...</p>
   if (isError) return <p>{error?.message}</p>
   if (devices == null) return null
@@ -43,22 +62,31 @@ export function DeviceTable({ onBack, ...props }: DeviceTableProps) {
       </TableHeader>
       <TableBody>
         {devices.map((device) => (
-          <DeviceRow device={device} key={device.device_id} />
+          <DeviceRow
+            device={device}
+            key={device.device_id}
+            onClick={() => {
+              selectDevice(device)
+            }}
+          />
         ))}
       </TableBody>
     </div>
   )
 }
 
-function DeviceRow(props: { device: UseDevicesData[number] }) {
-  const { device } = props
+function DeviceRow(props: {
+  device: UseDevicesData[number]
+  onClick: () => void
+}) {
+  const { device, onClick } = props
 
   if (!isLockDevice(device)) return null
 
   const deviceModel = getDeviceModel(device) ?? t.unknownLock
 
   return (
-    <TableRow key={device.device_id}>
+    <TableRow key={device.device_id} onClick={onClick}>
       <TableCell className='seam-image-cell'>
         <DeviceImage device={device} />
       </TableCell>

--- a/src/lib/ui/Table/TableRow.tsx
+++ b/src/lib/ui/Table/TableRow.tsx
@@ -1,5 +1,11 @@
 import type { DivProps } from 'lib/ui/types.js'
 
-export function TableRow(props: DivProps): JSX.Element {
-  return <div className='seam-table-row'>{props.children}</div>
+export function TableRow(
+  props: DivProps & { onClick?: () => void }
+): JSX.Element {
+  return (
+    <div className='seam-table-row' {...props}>
+      {props.children}
+    </div>
+  )
 }

--- a/src/lib/ui/layout/ContentHeader.tsx
+++ b/src/lib/ui/layout/ContentHeader.tsx
@@ -3,11 +3,16 @@ import { ArrowBackIcon } from 'lib/icons/ArrowBack.js'
 export function ContentHeader(props: {
   title?: string
   onBack?: () => void
-}): JSX.Element {
+}): JSX.Element | null {
+  const { title, onBack } = props
+  if (!title && !onBack) {
+    return null
+  }
+
   return (
     <div className='seam-content-header'>
-      <BackIcon onClick={props.onBack} />
-      <span className='seam-title'>{props.title}</span>
+      <BackIcon onClick={onBack} />
+      <span className='seam-title'>{title}</span>
     </div>
   )
 }

--- a/src/styles/_access-code-details.scss
+++ b/src/styles/_access-code-details.scss
@@ -2,12 +2,12 @@
 
 @mixin all {
   .seam-access-code-details {
-    padding: 0 24px 24px;
 
     > .seam-summary {
       background: colors.$bg-a;
       border-radius: 16px;
       margin-bottom: 16px;
+      margin: 0 24px 16px;
 
       > .seam-top {
         padding: 24px 16px;
@@ -81,6 +81,7 @@
       font-size: 16px;
       line-height: 134%;
       border-bottom: 1px solid rgb(0 0 0 / 12%);
+      padding: 0 24px;
 
       .seam-row {
         padding: 16px;

--- a/src/styles/_access-code-table.scss
+++ b/src/styles/_access-code-table.scss
@@ -2,6 +2,11 @@
 
 @mixin all {
   .seam-access-code-table {
+
+    .seam-table-row {
+
+      cursor: pointer;
+
     .seam-icon-cell {
       flex: 0;
       display: flex;
@@ -43,4 +48,5 @@
       justify-content: center;
     }
   }
+    }
 }

--- a/src/styles/_device-details.scss
+++ b/src/styles/_device-details.scss
@@ -2,12 +2,12 @@
 
 @mixin all {
   .seam-device-details {
-    padding: 0 24px 24px;
 
     .seam-body {
       display: flex;
       flex-direction: column;
       gap: 16px;
+      margin: 0 24px 24px;
 
       .seam-box {
         border: 1px solid colors.$text-gray-3;

--- a/src/styles/_device-table.scss
+++ b/src/styles/_device-table.scss
@@ -2,54 +2,57 @@
 
 @mixin all {
   .seam-device-table {
-    .seam-image-cell {
-      width: 64px;
-      height: 64px;
-      padding: 4px;
+    .seam-table-row {
+      cursor: pointer;
+      .seam-image-cell {
+        width: 64px;
+        height: 64px;
+        padding: 4px;
 
-      img {
-        width: 100%;
-      }
-    }
-
-    .seam-body-cell {
-      flex: 1;
-      flex-direction: column;
-      justify-content: center;
-      align-items: flex-start;
-      gap: 2px;
-
-      .seam-bottom {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        width: 100%;
-
-        .seam-device-model {
-          font-weight: 400;
-          font-size: 14px;
-          line-height: 134%;
-          color: colors.$text-gray-1;
-          flex: 0 1 190px;
-          white-space: nowrap;
-          overflow: hidden;
-          text-overflow: ellipsis;
+        img {
+          width: 100%;
         }
+      }
 
-        .seam-device-statuses {
+      .seam-body-cell {
+        flex: 1;
+        flex-direction: column;
+        justify-content: center;
+        align-items: flex-start;
+        gap: 2px;
+
+        .seam-bottom {
           display: flex;
+          justify-content: space-between;
           align-items: center;
-          color: colors.$text-gray-1;
-          font-size: 14px;
-          line-height: 134%;
+          width: 100%;
 
-          > div {
+          .seam-device-model {
+            font-weight: 400;
+            font-size: 14px;
+            line-height: 134%;
+            color: colors.$text-gray-1;
+            flex: 0 1 190px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
+
+          .seam-device-statuses {
             display: flex;
             align-items: center;
-            margin-right: 16px;
+            color: colors.$text-gray-1;
+            font-size: 14px;
+            line-height: 134%;
 
-            svg {
-              scale: 0.75;
+            > div {
+              display: flex;
+              align-items: center;
+              margin-right: 16px;
+
+              svg {
+                scale: 0.75;
+              }
             }
           }
         }

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -12,7 +12,7 @@
     .seam-back-icon {
       position: absolute;
       top: 50%;
-      transform: translate(0, -25%);
+      transform: translate(4px, -25%);
       left: 0;
       cursor: pointer;
     }

--- a/src/styles/_tables.scss
+++ b/src/styles/_tables.scss
@@ -5,7 +5,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 16px;
     height: 56px;
     padding: 0 16px;
   }


### PR DESCRIPTION
Closes #123 
Closes #92 


https://github.com/seamapi/react/assets/11449462/65883349-44b1-47a8-97cf-7a3e636dbb06

Currently only `useDevice` is stubbed via `useFakeDevice`. Once the CST auth is updated for `device.get` in seam-connect we can replace it with the real one.