### PR TITLE
Device - Add lock/unlock

### DIFF
--- a/src/lib/seam/access-codes/use-access-codes.ts
+++ b/src/lib/seam/access-codes/use-access-codes.ts
@@ -24,7 +24,7 @@ export function useAccessCodes(
     AccessCodesListResponse['access_codes'],
     SeamError
   >({
-    enabled: client != null,
+    enabled: client != null && normalizedParams.device_id != null,
     queryKey: ['access_codes', 'list', normalizedParams],
     queryFn: async () => {
       if (client == null) return []

--- a/src/lib/seam/access-codes/use-access-codes.ts
+++ b/src/lib/seam/access-codes/use-access-codes.ts
@@ -24,7 +24,7 @@ export function useAccessCodes(
     AccessCodesListResponse['access_codes'],
     SeamError
   >({
-    enabled: client != null && normalizedParams.device_id != null,
+    enabled: client != null,
     queryKey: ['access_codes', 'list', normalizedParams],
     queryFn: async () => {
       if (client == null) return []

--- a/src/lib/seam/devices/use-device.ts
+++ b/src/lib/seam/devices/use-device.ts
@@ -4,7 +4,6 @@ import type {
   Device,
   DeviceGetRequest,
   DeviceGetResponse,
-  LockDevice,
   SeamError,
 } from 'seamapi'
 
@@ -34,49 +33,4 @@ export function useDevice(
   })
 
   return { ...rest, device: data }
-}
-
-export function useFakeDevice(_params: DeviceGetRequest): {
-  isLoading: boolean
-  device: UseDeviceData
-} {
-  const device: LockDevice = {
-    device_id: 'f9a9ab36-9e14-4390-a88c-b4c78304c6aa',
-    device_type: 'august_lock',
-    capabilities_supported: ['access_code', 'lock'],
-    properties: {
-      locked: true,
-      online: true,
-      door_open: false,
-      manufacturer: 'august',
-      battery_level: 0.9999532347993827,
-      serial_number: '00000004-992d-45a0-bea1-9128fdcd8d12',
-      august_metadata: {
-        lock_id: 'lock-1',
-        house_id: 'house-1',
-        lock_name: 'FRONT DOOR',
-        has_keypad: true,
-        house_name: 'My House',
-      },
-      supported_code_lengths: [6],
-      name: 'FRONT DOOR',
-      battery: {
-        level: 0.9999532347993827,
-        status: 'full',
-      },
-      image_url:
-        'https://connect.getseam.com/assets/images/devices/august_wifi-smart-lock-3rd-gen_silver_front.png',
-    },
-    location: {
-      timezone: 'America/Los_Angeles',
-      location_name: 'My House',
-    },
-    connected_account_id: '6fc0f854-cb5a-461a-af93-e543ce1f730f',
-    workspace_id: 'a9598de8-e627-4d01-b119-61ab7b9e07bd',
-    created_at: '2023-05-08T22:37:24.206Z',
-    errors: [],
-    warnings: [],
-  }
-
-  return { isLoading: false, device }
 }

--- a/src/lib/seam/devices/use-devices.ts
+++ b/src/lib/seam/devices/use-devices.ts
@@ -18,7 +18,7 @@ export function useDevices(
   params?: UseDevicesParams
 ): UseSeamQueryResult<'devices', UseDevicesData> {
   const { client } = useSeamClient()
-  const qc = useQueryClient()
+  const queryClient = useQueryClient()
 
   const { data, ...rest } = useQuery<DevicesListResponse['devices'], SeamError>(
     {

--- a/src/lib/seam/devices/use-devices.ts
+++ b/src/lib/seam/devices/use-devices.ts
@@ -30,7 +30,7 @@ export function useDevices(
         return devices.sort(byCreatedAt)
       },
       onSuccess(devices) {
-        // Pre-load device data in cache to avoid load times
+        // Prime cache for each device.
         for (const device of devices) {
           queryClient.setQueryData(
             ['devices', 'get', { device_id: device.device_id }],

--- a/src/lib/seam/devices/use-devices.ts
+++ b/src/lib/seam/devices/use-devices.ts
@@ -30,6 +30,7 @@ export function useDevices(
         return devices.sort(byCreatedAt)
       },
       onSuccess(devices) {
+        // Pre-load device data in cache to avoid load times
         for (const device of devices) {
           qc.setQueryData(
             ['devices', 'get', { device_id: device.device_id }],

--- a/src/lib/seam/devices/use-devices.ts
+++ b/src/lib/seam/devices/use-devices.ts
@@ -32,7 +32,7 @@ export function useDevices(
       onSuccess(devices) {
         // Pre-load device data in cache to avoid load times
         for (const device of devices) {
-          qc.setQueryData(
+          queryClient.setQueryData(
             ['devices', 'get', { device_id: device.device_id }],
             device
           )

--- a/src/lib/seam/devices/use-devices.ts
+++ b/src/lib/seam/devices/use-devices.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import type {
   CommonDeviceProperties,
   Device,
@@ -18,6 +18,8 @@ export function useDevices(
   params?: UseDevicesParams
 ): UseSeamQueryResult<'devices', UseDevicesData> {
   const { client } = useSeamClient()
+  const qc = useQueryClient()
+
   const { data, ...rest } = useQuery<DevicesListResponse['devices'], SeamError>(
     {
       enabled: client != null,
@@ -26,6 +28,14 @@ export function useDevices(
         if (client == null) return []
         const devices = await client?.devices.list(params)
         return devices.sort(byCreatedAt)
+      },
+      onSuccess(devices) {
+        for (const device of devices) {
+          qc.setQueryData(
+            ['devices', 'get', { device_id: device.device_id }],
+            device
+          )
+        }
       },
     }
   )

--- a/src/lib/seam/devices/use-toggle-lock.ts
+++ b/src/lib/seam/devices/use-toggle-lock.ts
@@ -60,7 +60,7 @@ export function useToggleLock({
         }
       )
 
-      qc.setQueryData<LockDevice>(
+      queryClient.setQueryData<LockDevice>(
         ['devices', 'get', { device_id: deviceId }],
         (device) => {
           if (device == null) {

--- a/src/lib/seam/devices/use-toggle-lock.ts
+++ b/src/lib/seam/devices/use-toggle-lock.ts
@@ -24,8 +24,7 @@ export function useToggleLock({
   void
 > {
   const { client } = useSeamClient()
-
-  const qc = useQueryClient()
+  const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async () => {

--- a/src/lib/seam/devices/use-toggle-lock.ts
+++ b/src/lib/seam/devices/use-toggle-lock.ts
@@ -44,19 +44,18 @@ export function useToggleLock({
           }
 
           return devices.map((d) => {
-            const isTarget = d.device_id === deviceId
-
+            const isTarget = device.device_id === deviceId
             if (isTarget && isLockDevice(d)) {
               return {
-                ...d,
+                ...device,
                 properties: {
-                  ...d.properties,
-                  locked: !d.properties.locked,
+                  ...device.properties,
+                  locked: !device.properties.locked,
                 },
               }
             }
 
-            return d
+            return device
           })
         }
       )

--- a/src/lib/seam/devices/use-toggle-lock.ts
+++ b/src/lib/seam/devices/use-toggle-lock.ts
@@ -1,0 +1,91 @@
+import {
+  useMutation,
+  type UseMutationResult,
+  useQueryClient,
+} from '@tanstack/react-query'
+import type {
+  ActionAttempt,
+  CommonDeviceProperties,
+  Device,
+  LockDevice,
+  SeamError,
+} from 'seamapi'
+
+import { useSeamClient } from 'lib/index.js'
+
+import { isLockDevice } from 'lib/seam/devices/types.js'
+
+export function useToggleLock({
+  device_id: deviceId,
+  properties: { locked },
+}: LockDevice): UseMutationResult<
+  { actionAttempt: ActionAttempt },
+  SeamError,
+  void
+> {
+  const { client } = useSeamClient()
+
+  const qc = useQueryClient()
+
+  return useMutation({
+    mutationFn: async () => {
+      if (client == null) {
+        throw new Error('Missing seam client')
+      }
+
+      const toggle = locked ? client.locks.unlockDoor : client.locks.lockDoor
+      return await toggle(deviceId)
+    },
+    onMutate: () => {
+      qc.setQueryData<Array<Device<CommonDeviceProperties>>>(
+        ['devices', 'list', {}],
+        (devices) => {
+          if (devices == null) {
+            return
+          }
+
+          return devices.map((d) => {
+            const isTarget = d.device_id === deviceId
+
+            if (isTarget && isLockDevice(d)) {
+              return {
+                ...d,
+                properties: {
+                  ...d.properties,
+                  locked: !d.properties.locked,
+                },
+              }
+            }
+
+            return d
+          })
+        }
+      )
+
+      qc.setQueryData<LockDevice>(
+        ['devices', 'get', { device_id: deviceId }],
+        (device) => {
+          if (device == null) {
+            return
+          }
+
+          return {
+            ...device,
+            properties: {
+              ...device.properties,
+              locked: !device.properties.locked,
+            },
+          }
+        }
+      )
+    },
+    onSettled: async () => {
+      await qc.invalidateQueries({
+        queryKey: ['devices', 'list'],
+      })
+      await qc.invalidateQueries({
+        queryKey: ['devices', 'get', { device_id: deviceId }],
+      })
+    },
+  })
+}

--- a/src/lib/seam/devices/use-toggle-lock.ts
+++ b/src/lib/seam/devices/use-toggle-lock.ts
@@ -36,7 +36,7 @@ export function useToggleLock({
       return await toggle(deviceId)
     },
     onMutate: () => {
-      qc.setQueryData<Array<Device<CommonDeviceProperties>>>(
+      queryClient.setQueryData<Array<Device<CommonDeviceProperties>>>(
         ['devices', 'list', {}],
         (devices) => {
           if (devices == null) {

--- a/src/lib/seam/devices/use-toggle-lock.ts
+++ b/src/lib/seam/devices/use-toggle-lock.ts
@@ -43,9 +43,9 @@ export function useToggleLock({
             return
           }
 
-          return devices.map((d) => {
+          return devices.map((device) => {
             const isTarget = device.device_id === deviceId
-            if (isTarget && isLockDevice(d)) {
+            if (isTarget && isLockDevice(device)) {
               return {
                 ...device,
                 properties: {
@@ -78,10 +78,10 @@ export function useToggleLock({
       )
     },
     onSettled: async () => {
-      await qc.invalidateQueries({
+      await queryClient.invalidateQueries({
         queryKey: ['devices', 'list'],
       })
-      await qc.invalidateQueries({
+      await queryClient.invalidateQueries({
         queryKey: ['devices', 'get', { device_id: deviceId }],
       })
     },

--- a/src/lib/ui/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/ui/AccessCodeDetails/AccessCodeDetails.tsx
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
 import { useState } from 'react'
-import type { AccessCode, CommonDeviceProperties, Device } from 'seamapi'
+import type { AccessCode } from 'seamapi'
 
 import { AccessCodeDevice } from 'lib/ui/AccessCodeDetails/AccessCodeDevice.js'
 import { DeviceDetails } from 'lib/ui/DeviceDetails/DeviceDetails.js'
@@ -17,13 +17,12 @@ export function AccessCodeDetails({
   onBack,
 }: AccessCodeDetailsProps): JSX.Element {
   const name = accessCode.name ?? t.fallbackName
-  const [selectedDevice, selectDevice] =
-    useState<Device<CommonDeviceProperties> | null>(null)
+  const [selectedDeviceId, selectDevice] = useState<string | null>(null)
 
-  if (selectedDevice != null) {
+  if (selectedDeviceId != null) {
     return (
       <DeviceDetails
-        device={selectedDevice}
+        deviceId={selectedDeviceId}
         onBack={() => {
           selectDevice(null)
         }}

--- a/src/lib/ui/Button.tsx
+++ b/src/lib/ui/Button.tsx
@@ -5,6 +5,7 @@ interface ButtonProps {
   variant?: 'solid' | 'outline' | 'neutral'
   size?: 'small' | 'medium' | 'large'
   disabled?: boolean
+  onClick?: () => void
 }
 
 export function Button({
@@ -12,6 +13,7 @@ export function Button({
   children,
   size = 'medium',
   disabled,
+  onClick,
 }: ButtonProps): JSX.Element {
   return (
     <button
@@ -19,6 +21,7 @@ export function Button({
         'seam-btn-disabled': disabled,
       })}
       disabled={disabled}
+      onClick={onClick}
     >
       {children}
     </button>

--- a/src/lib/ui/DeviceDetails/DeviceDetails.stories.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.stories.tsx
@@ -1,36 +1,12 @@
 import { Close as CloseIcon } from '@mui/icons-material'
 import { Button, Dialog, DialogActions, IconButton } from '@mui/material'
 import type { Meta, StoryObj } from '@storybook/react'
-import type { LockDevice } from 'seamapi'
 
 import {
   DeviceDetails,
   type DeviceDetailsProps,
 } from 'lib/ui/DeviceDetails/DeviceDetails.js'
 import useToggle from 'lib/use-toggle.js'
-
-const fakeDevice: LockDevice = {
-  workspace_id: '0f272652-7bdd-4abc-9fb0-616f25c2213e',
-  device_id: 'fc4eef92-951f-4954-8358-742ca90516e0',
-  connected_account_id: '4de4e249-17c2-4bbc-8828-08aaac6fd098',
-  device_type: 'august_lock',
-  created_at: '2022-12-18T04:35:20.737Z',
-  properties: {
-    name: 'Room 101 Front Door',
-    battery_level: 0.2,
-    locked: true,
-    online: true,
-    schlage_metadata: {
-      model: 'Schlage Lock',
-      device_id: '95b0c8fd-ab40-4dcb-9f73-3c20f89cea19',
-      device_name: 'Lock',
-      access_code_length: 6,
-    },
-  },
-  errors: [],
-  warnings: [],
-  capabilities_supported: [],
-}
 
 /**
  * These stories showcase the device manager.
@@ -39,7 +15,7 @@ const meta: Meta<typeof DeviceDetails> = {
   title: 'Example/DeviceDetails',
   component: DeviceDetails,
   args: {
-    device: fakeDevice,
+    deviceId: '6c874099-0a92-4eb1-92a5-993db45efffc',
   },
   tags: ['autodocs'],
 }

--- a/src/lib/ui/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.tsx
@@ -1,8 +1,11 @@
-import { type CommonDeviceProperties, type Device } from 'seamapi'
+import { type LockDevice } from 'seamapi'
+
+import { useDevice } from 'lib/index.js'
 
 import { ChevronRightIcon } from 'lib/icons/ChevronRight.js'
 import { useAccessCodes } from 'lib/seam/access-codes/use-access-codes.js'
 import { isLockDevice } from 'lib/seam/devices/types.js'
+import { useToggleLock } from 'lib/seam/devices/use-toggle-lock.js'
 import { AccessCodeTable } from 'lib/ui/AccessCodeTable/AccessCodeTable.js'
 import { Button } from 'lib/ui/Button.js'
 import { BatteryStatus } from 'lib/ui/device/BatteryStatus.js'
@@ -13,20 +16,45 @@ import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
 import useToggle from 'lib/use-toggle.js'
 
 export interface DeviceDetailsProps {
-  device: Device<CommonDeviceProperties>
+  deviceId: string
   onBack?: () => void
 }
 
 export function DeviceDetails(props: DeviceDetailsProps): JSX.Element | null {
-  const { device, onBack } = props
+  const { deviceId, onBack } = props
 
+  const { device } = useDevice({
+    device_id: deviceId,
+  })
+
+  if (device == null) {
+    return null
+  }
+
+  if (!isLockDevice(device)) {
+    return null
+  }
+
+  return <LockDeviceDetails device={device} onBack={onBack} />
+}
+
+function LockDeviceDetails(props: { device: LockDevice; onBack?: () => void }) {
   const [accessCodesOpen, toggleAccessCodesOpen] = useToggle()
-
-  const { isLoading, accessCodes } = useAccessCodes({
+  const { device, onBack } = props
+  const toggleLock = useToggleLock(device)
+  const { accessCodes } = useAccessCodes({
     device_id: device.device_id,
   })
 
-  if (isLoading) {
+  const lockStatus = device.properties.locked ? t.locked : t.unlocked
+  const toggleLockLabel = device.properties.locked ? t.unlock : t.lock
+
+  const accessCodeCount = accessCodes?.length
+
+  const accessCodeLength =
+    device.properties?.schlage_metadata?.access_code_length
+
+  if (accessCodes == null) {
     return null
   }
 
@@ -38,17 +66,6 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element | null {
       />
     )
   }
-
-  if (!isLockDevice(device)) {
-    return null
-  }
-
-  const lockStatus = device.properties.locked ? t.locked : t.unlocked
-
-  const accessCodeCount = accessCodes?.length
-
-  const accessCodeLength =
-    device.properties?.schlage_metadata?.access_code_length
 
   return (
     <div className='seam-device-details'>
@@ -91,7 +108,14 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element | null {
               <span className='seam-value'>{lockStatus}</span>
             </div>
             <div className='seam-right'>
-              <Button size='small'>{t.unlock}</Button>
+              <Button
+                size='small'
+                onClick={() => {
+                  toggleLock.mutate()
+                }}
+              >
+                {toggleLockLabel}
+              </Button>
             </div>
           </div>
           <AccessCodeLength accessCodeLength={accessCodeLength} />
@@ -122,6 +146,7 @@ function AccessCodeLength(props: {
 const t = {
   device: 'Device',
   unlock: 'Unlock',
+  lock: 'Lock',
   locked: 'Locked',
   unlocked: 'Unlocked',
   accessCodes: 'access codes',

--- a/src/lib/ui/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.tsx
@@ -39,8 +39,8 @@ export function DeviceDetails(props: DeviceDetailsProps): JSX.Element | null {
 }
 
 function LockDeviceDetails(props: { device: LockDevice; onBack?: () => void }) {
-  const [accessCodesOpen, toggleAccessCodesOpen] = useToggle()
   const { device, onBack } = props
+  const [accessCodesOpen, toggleAccessCodesOpen] = useToggle()
   const toggleLock = useToggleLock(device)
   const { accessCodes } = useAccessCodes({
     device_id: device.device_id,

--- a/src/lib/ui/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/ui/DeviceDetails/DeviceDetails.tsx
@@ -1,4 +1,4 @@
-import { type LockDevice } from 'seamapi'
+import type { LockDevice } from 'seamapi'
 
 import { useDevice } from 'lib/index.js'
 

--- a/src/lib/ui/DeviceTable/DeviceTable.tsx
+++ b/src/lib/ui/DeviceTable/DeviceTable.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import type { CommonDeviceProperties, Device } from 'seamapi'
 
 import { isLockDevice } from 'lib/seam/devices/types.js'
 import {
@@ -34,13 +33,12 @@ export function DeviceTable({
 }: DeviceTableProps): JSX.Element | null {
   const { devices, isLoading, isError, error } = useDevices(props)
 
-  const [selectedDevice, selectDevice] =
-    useState<Device<CommonDeviceProperties> | null>(null)
+  const [selectedDeviceId, selectDevice] = useState<string | null>(null)
 
-  if (selectedDevice != null) {
+  if (selectedDeviceId != null) {
     return (
       <DeviceDetails
-        device={selectedDevice}
+        deviceId={selectedDeviceId}
         onBack={() => {
           selectDevice(null)
         }}
@@ -76,7 +74,7 @@ export function DeviceTable({
             device={device}
             key={device.device_id}
             onClick={() => {
-              selectDevice(device)
+              selectDevice(device.device_id)
             }}
           />
         ))}


### PR DESCRIPTION
Closes #110 

![image](https://github.com/seamapi/react/assets/11449462/67ecd293-4472-42d6-ac5f-6e8d7941692b)

### Notable things

- Optimistic UI updates via `onMutate` for snappy UI.
- Set query data manually on `device.list` to pre-populate `device.get`.
- Pass `deviceId` to `<DeviceDetails/>` to avoid maintaining duplicate state.
- Removed `useFakeDevice` (no longer required).

### Dependencies

- Need to update both the `/lock_door`, and `/unlock_door` endpoints on `seam-connect` with client session token auth.

![image](https://github.com/seamapi/react/assets/11449462/baddd25a-21bc-432e-b80c-739b6a8e6d9e)
