### PR TITLE
Always use the fake (unless very explicitly opted out)

### DIFF
--- a/.storybook/middleware.js
+++ b/.storybook/middleware.js
@@ -11,6 +11,8 @@ export default async (app) => {
   seedFake(fake.database.getState())
   await fake.startServer()
 
+  console.log(`Fake server running at: "${fake.server.serverUrl}"`)
+
   app.use(
     '/',
     createProxyMiddleware('/api', {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,25 +3,24 @@ import '../src/index.scss'
 import { SeamProvider } from '@seamapi/react'
 import type { Preview } from '@storybook/react'
 
-import { fakePublishableKey, fakeUserIdentifierKey } from './seed-fake.js'
-
-const isProd = process.env['NODE_ENV'] === 'production'
-const useFake = process.env['STORYBOOK_SEAM_ENDPOINT'] == null
+// process.env['STORYBOOK_SEAM_ENDPOINT'] == null
+const useFake = true
 
 const preview: Preview = {
   globalTypes: {
     /** @deprecated use "seam_pk1ws2_0000" **/
     publishableKey: {
       description: 'Seam publishable key',
-      defaultValue:
-        process.env['STORYBOOK_SEAM_PUBLISHABLE_KEY'] ?? fakePublishableKey,
+      defaultValue: useFake
+        ? 'seam_pk1ws2_0000'
+        : process.env['STORYBOOK_SEAM_PUBLISHABLE_KEY'],
     },
     /** @deprecated use "seed_client_session_user_2" **/
     userIdentifierKey: {
       description: 'Seam user identifier key',
-      defaultValue:
-        process.env['STORYBOOK_SEAM_USER_IDENTIFIER_KEY'] ??
-        fakeUserIdentifierKey,
+      defaultValue: useFake
+        ? 'seed_client_session_user_2'
+        : process.env['STORYBOOK_SEAM_USER_IDENTIFIER_KEY'],
     },
     /** @deprecated use "device1" **/
     deviceId: {
@@ -37,6 +36,10 @@ const preview: Preview = {
         ? 'access_code1'
         : 'a4d00b36-09e2-467f-a9f3-bb73cea1351c',
     },
+    seamEndpoint: {
+      description: 'Seam Endpoint',
+      defaultValue: useFake ? '/api' : process.env['STORYBOOK_SEAM_ENDPOINT'],
+    },
   },
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
@@ -48,12 +51,15 @@ const preview: Preview = {
     },
   },
   decorators: [
-    (Story, { globals: { publishableKey, userIdentifierKey } }) => {
+    (
+      Story,
+      { globals: { publishableKey, userIdentifierKey, seamEndpoint } }
+    ) => {
       return (
         <SeamProvider
           publishableKey={publishableKey}
           userIdentifierKey={userIdentifierKey}
-          endpoint='/api'
+          endpoint={seamEndpoint}
         >
           <Story />
         </SeamProvider>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,9 +4,9 @@ import { SeamProvider } from '@seamapi/react'
 import type { Preview } from '@storybook/react'
 
 const useFake =
-  !['1', 'true'].includes(
+  !(['1', 'true'].includes(
     process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase() ?? ''
-  ) && process.env['STORYBOOK_SEAM_ENDPOINT'] == null
+  )
 
 const preview: Preview = {
   globalTypes: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,23 +3,24 @@ import '../src/index.scss'
 import { SeamProvider } from '@seamapi/react'
 import type { Preview } from '@storybook/react'
 
-// process.env['STORYBOOK_SEAM_ENDPOINT'] == null
-const useFake = true
+const useFake =
+  process.env['DONT_USE_FAKE'] === '1' &&
+  process.env['STORYBOOK_SEAM_ENDPOINT'] == null
 
 const preview: Preview = {
   globalTypes: {
-    /** @deprecated use "seam_pk1ws2_0000" **/
+    /** @deprecated use "some_publishable_key" **/
     publishableKey: {
       description: 'Seam publishable key',
       defaultValue: useFake
-        ? 'seam_pk1ws2_0000'
+        ? 'some_publishable_key'
         : process.env['STORYBOOK_SEAM_PUBLISHABLE_KEY'],
     },
-    /** @deprecated use "seed_client_session_user_2" **/
+    /** @deprecated use "some_user_identifier_key" **/
     userIdentifierKey: {
       description: 'Seam user identifier key',
       defaultValue: useFake
-        ? 'seed_client_session_user_2'
+        ? 'some_user_identifier_key'
         : process.env['STORYBOOK_SEAM_USER_IDENTIFIER_KEY'],
     },
     /** @deprecated use "device1" **/

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,7 +6,7 @@ import type { Preview } from '@storybook/react'
 const useFake =
   !(['1', 'true'].includes(
     process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase() ?? ''
-  )
+  ))
 
 const preview: Preview = {
   globalTypes: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,7 +4,7 @@ import { SeamProvider } from '@seamapi/react'
 import type { Preview } from '@storybook/react'
 
 const useFake =
-  process.env['DONT_USE_FAKE'] === '1' &&
+  ['1','true'].includes(process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase()) &&
   process.env['STORYBOOK_SEAM_ENDPOINT'] == null
 
 const preview: Preview = {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,8 +4,9 @@ import { SeamProvider } from '@seamapi/react'
 import type { Preview } from '@storybook/react'
 
 const useFake =
-  ['1','true'].includes(process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase()) &&
-  process.env['STORYBOOK_SEAM_ENDPOINT'] == null
+  ['1', 'true'].includes(
+    process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase()
+  ) && process.env['STORYBOOK_SEAM_ENDPOINT'] == null
 
 const preview: Preview = {
   globalTypes: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,23 +10,27 @@ const useFake = process.env['STORYBOOK_SEAM_ENDPOINT'] == null
 
 const preview: Preview = {
   globalTypes: {
+    /** @deprecated use "seam_pk1ws2_0000" **/
     publishableKey: {
       description: 'Seam publishable key',
       defaultValue:
         process.env['STORYBOOK_SEAM_PUBLISHABLE_KEY'] ?? fakePublishableKey,
     },
+    /** @deprecated use "seed_client_session_user_2" **/
     userIdentifierKey: {
       description: 'Seam user identifier key',
       defaultValue:
         process.env['STORYBOOK_SEAM_USER_IDENTIFIER_KEY'] ??
         fakeUserIdentifierKey,
     },
+    /** @deprecated use "device1" **/
     deviceId: {
       description: 'Device id',
       defaultValue: useFake
         ? 'device1'
         : 'f9a9ab36-9e14-4390-a88c-b4c78304c6aa',
     },
+    /** @deprecated use "access_code1" **/
     accessCodeId: {
       description: 'Access code id',
       defaultValue: useFake
@@ -49,7 +53,7 @@ const preview: Preview = {
         <SeamProvider
           publishableKey={publishableKey}
           userIdentifierKey={userIdentifierKey}
-          {...(isProd ? {} : { endpoint: '/api' })}
+          endpoint='/api'
         >
           <Story />
         </SeamProvider>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,7 +4,7 @@ import { SeamProvider } from '@seamapi/react'
 import type { Preview } from '@storybook/react'
 
 const useFake =
-  ['1', 'true'].includes(
+  !['1', 'true'].includes(
     process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase() ?? ''
   ) && process.env['STORYBOOK_SEAM_ENDPOINT'] == null
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,7 +5,7 @@ import type { Preview } from '@storybook/react'
 
 const useFake =
   ['1', 'true'].includes(
-    process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase()
+    process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase() ?? ''
   ) && process.env['STORYBOOK_SEAM_ENDPOINT'] == null
 
 const preview: Preview = {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,10 +3,9 @@ import '../src/index.scss'
 import { SeamProvider } from '@seamapi/react'
 import type { Preview } from '@storybook/react'
 
-const useFake =
-  !(['1', 'true'].includes(
-    process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase() ?? ''
-  ))
+const useFake = !['1', 'true'].includes(
+  process.env['STORYBOOK_DISABLE_FAKE']?.toLowerCase() ?? ''
+)
 
 const preview: Preview = {
   globalTypes: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,28 +9,28 @@ const useFake = !['1', 'true'].includes(
 
 const preview: Preview = {
   globalTypes: {
-    /** @deprecated use "some_publishable_key" **/
+    /** @deprecated use "seam_pk_1" directly in your story **/
     publishableKey: {
       description: 'Seam publishable key',
       defaultValue: useFake
-        ? 'some_publishable_key'
+        ? 'seam_pk_1'
         : process.env['STORYBOOK_SEAM_PUBLISHABLE_KEY'],
     },
-    /** @deprecated use "some_user_identifier_key" **/
+    /** @deprecated use "some_user" directly in your story **/
     userIdentifierKey: {
       description: 'Seam user identifier key',
       defaultValue: useFake
-        ? 'some_user_identifier_key'
+        ? 'some_user'
         : process.env['STORYBOOK_SEAM_USER_IDENTIFIER_KEY'],
     },
-    /** @deprecated use "device1" **/
+    /** @deprecated use "device1" directly in your story **/
     deviceId: {
       description: 'Device id',
       defaultValue: useFake
         ? 'device1'
         : 'f9a9ab36-9e14-4390-a88c-b4c78304c6aa',
     },
-    /** @deprecated use "access_code1" **/
+    /** @deprecated use "access_code1" directly in your story **/
     accessCodeId: {
       description: 'Access code id',
       defaultValue: useFake
@@ -39,7 +39,12 @@ const preview: Preview = {
     },
     seamEndpoint: {
       description: 'Seam Endpoint',
-      defaultValue: useFake ? '/api' : process.env['STORYBOOK_SEAM_ENDPOINT'],
+      defaultValue: useFake
+        ? // special hack for chromatic ui reviews that don't run the fake
+          window?.location?.href.includes('chromatic')
+          ? 'https://seam-react.vercel.app/api'
+          : '/api'
+        : process.env['STORYBOOK_SEAM_ENDPOINT'],
     },
   },
   parameters: {

--- a/.storybook/seed-fake.js
+++ b/.storybook/seed-fake.js
@@ -160,5 +160,5 @@ export const seedFake = (db) => {
   })
 }
 
-export const fakePublishableKey = 'seam_pk1ws2_0000'
-export const fakeUserIdentifierKey = 'seed_client_session_user_2'
+export const fakePublishableKey = 'some_publishable_key'
+export const fakeUserIdentifierKey = 'some_user_identifier_key'

--- a/.storybook/seed-fake.js
+++ b/.storybook/seed-fake.js
@@ -2,7 +2,7 @@
 export const seedFake = (db) => {
   db.addWorkspace({
     name: 'Seed Workspace 1 (starts empty)',
-    publishable_key: 'seam_pk1ws1_0000',
+    publishable_key: 'seam_pk_1',
   })
 
   const ws2 = db.addWorkspace({
@@ -160,5 +160,5 @@ export const seedFake = (db) => {
   })
 }
 
-export const fakePublishableKey = 'some_publishable_key'
-export const fakeUserIdentifierKey = 'some_user_identifier_key'
+export const fakePublishableKey = 'seam_pk_1'
+export const fakeUserIdentifierKey = 'some_user'

--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ $ npm run docs:start
 
 [Storybook]: https://storybook.js.org/
 
+### Fake Seam Connect
+
+This project uses a [fake version of Seam Connect](https://github.com/seamapi/fake-seam-connect)
+to have deterministic responses for rendering views. You can edit the seed data
+for the fake, or find ids that could be useful for testing components in
+[seed-fake.js](.storybook/seed-fake.js).
+
 ### Previews
 
 Every pull request deploys the Storybook with the examples

--- a/examples/.env.storybook
+++ b/examples/.env.storybook
@@ -1,2 +1,2 @@
-SEAM_PUBLISHABLE_KEY=seam_pk1ws2_0000
-SEAM_USER_IDENTIFIER_KEY=seed_client_session_user_2
+SEAM_PUBLISHABLE_KEY=some_publishable_key
+SEAM_USER_IDENTIFIER_KEY=some_user_identifier_key

--- a/examples/.env.storybook
+++ b/examples/.env.storybook
@@ -1,2 +1,2 @@
-SEAM_PUBLISHABLE_KEY=some_publishable_key
-SEAM_USER_IDENTIFIER_KEY=some_user_identifier_key
+SEAM_PUBLISHABLE_KEY=seam_pk_1
+SEAM_USER_IDENTIFIER_KEY=some_user

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -69,8 +69,8 @@ const setupEnv = async (
 ): Promise<void> => {
   if (useFake) {
     env['SEAM_ENDPOINT'] = endpoint
-    env['SEAM_PUBLISHABLE_KEY'] = 'some_publishable_key'
-    env['SEAM_USER_IDENTIFIER_KEY'] = 'some_user_identifier_key'
+    env['SEAM_PUBLISHABLE_KEY'] = 'seam_pk_1'
+    env['SEAM_USER_IDENTIFIER_KEY'] = 'some_user'
     return
   }
 

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -69,8 +69,8 @@ const setupEnv = async (
 ): Promise<void> => {
   if (useFake) {
     env['SEAM_ENDPOINT'] = endpoint
-    env['SEAM_PUBLISHABLE_KEY'] = 'seam_pk1ws2_0000'
-    env['SEAM_USER_IDENTIFIER_KEY'] = 'seed_client_session_user_2'
+    env['SEAM_PUBLISHABLE_KEY'] = 'some_publishable_key'
+    env['SEAM_USER_IDENTIFIER_KEY'] = 'some_user_identifier_key'
     return
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@emotion/styled": "^11.10.6",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.12.2",
-        "@seamapi/fake-seam-connect": "^0.3.0-alpha.8",
+        "@seamapi/fake-seam-connect": "^0.4.0",
         "@storybook/addon-essentials": "^7.0.2",
         "@storybook/addon-interactions": "^7.0.2",
         "@storybook/addon-links": "^7.0.2",
@@ -4024,9 +4024,9 @@
       }
     },
     "node_modules/@seamapi/fake-seam-connect": {
-      "version": "0.3.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-0.3.0-alpha.8.tgz",
-      "integrity": "sha512-ePCXD2xXIWd9hl2bkgAWuPnoPt8u1qkiAJTGlo4p/qVlg80gFgQ+TVGoZEo2zGk5mOlX9q7YrPMXQ+uCa6UZXg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-0.4.0.tgz",
+      "integrity": "sha512-iILvhRbG/jK2Zm3IvS0EMWy12sIaJ67kc1YcFf3d56Dhm9ND8PB/8FNWGah/eHBJ3F1r2EpB0Q+YgLDq0aCieA==",
       "dev": true,
       "engines": {
         "node": ">=16.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@emotion/styled": "^11.10.6",
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.12.2",
-        "@seamapi/fake-seam-connect": "^0.4.0",
+        "@seamapi/fake-seam-connect": "^0.4.1",
         "@storybook/addon-essentials": "^7.0.2",
         "@storybook/addon-interactions": "^7.0.2",
         "@storybook/addon-links": "^7.0.2",
@@ -4024,9 +4024,9 @@
       }
     },
     "node_modules/@seamapi/fake-seam-connect": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-0.4.0.tgz",
-      "integrity": "sha512-iILvhRbG/jK2Zm3IvS0EMWy12sIaJ67kc1YcFf3d56Dhm9ND8PB/8FNWGah/eHBJ3F1r2EpB0Q+YgLDq0aCieA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-0.4.1.tgz",
+      "integrity": "sha512-5os2GNqdAZc2GoXCtIhkZf5NVWJTcr8KVFWdQwQK1Y7ua/7bicJj8kEqn7IcO1PpSZfLL7/P9NAUyb4B/unGFw==",
       "dev": true,
       "engines": {
         "node": ">=16.13.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.2",
-    "@seamapi/fake-seam-connect": "^0.4.0",
+    "@seamapi/fake-seam-connect": "^0.4.1",
     "@storybook/addon-essentials": "^7.0.2",
     "@storybook/addon-interactions": "^7.0.2",
     "@storybook/addon-links": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@emotion/styled": "^11.10.6",
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.2",
-    "@seamapi/fake-seam-connect": "^0.3.0-alpha.8",
+    "@seamapi/fake-seam-connect": "^0.4.0",
     "@storybook/addon-essentials": "^7.0.2",
     "@storybook/addon-interactions": "^7.0.2",
     "@storybook/addon-links": "^7.0.2",

--- a/test/fixtures/react.tsx
+++ b/test/fixtures/react.tsx
@@ -18,7 +18,7 @@ function Providers({ children }: PropsWithChildren): JSX.Element {
     <SeamProvider
       endpoint={globalThis.JEST_SEAM_ENDPOINT}
       publishableKey={globalThis.JEST_SEAM_PUBLISHABLE_KEY_1}
-      userIdentifierKey='some_user_identifier_key'
+      userIdentifierKey='some_user'
     >
       {children}
     </SeamProvider>

--- a/test/fixtures/react.tsx
+++ b/test/fixtures/react.tsx
@@ -18,7 +18,7 @@ function Providers({ children }: PropsWithChildren): JSX.Element {
     <SeamProvider
       endpoint={globalThis.JEST_SEAM_ENDPOINT}
       publishableKey={globalThis.JEST_SEAM_PUBLISHABLE_KEY_1}
-      userIdentifierKey='seed_client_session_user_2'
+      userIdentifierKey='some_user_identifier_key'
     >
       {children}
     </SeamProvider>

--- a/test/jest/global-setup.cjs
+++ b/test/jest/global-setup.cjs
@@ -41,7 +41,7 @@ module.exports = async function (_globalConfig, projectConfig) {
     workspace_id: ws2.workspace_id,
     connect_webview_ids: [cw.connect_webview_id],
     connected_account_ids: [ca.connected_account_id],
-    user_identifier_key: 'some_user_identifier_key',
+    user_identifier_key: 'some_user',
   })
 
   await fake.startServer()

--- a/test/jest/global-setup.cjs
+++ b/test/jest/global-setup.cjs
@@ -41,7 +41,7 @@ module.exports = async function (_globalConfig, projectConfig) {
     workspace_id: ws2.workspace_id,
     connect_webview_ids: [cw.connect_webview_id],
     connected_account_ids: [ca.connected_account_id],
-    user_identifier_key: 'seed_client_session_user_2',
+    user_identifier_key: 'some_user_identifier_key',
   })
 
   await fake.startServer()


### PR DESCRIPTION
Makes the fake an opt-out experience. The production storybook now uses the read-only fake.

The only reason to support the real api at this point for the storybook is because the fake is read only so action attempts can't be polled, webviews can't be finished etc.

We'll have a fake setup that supports modifications soon that will support mutating, so it's a temporary limitation for some of the interactive storybooks.

Making sure everyone develops the same reproducible way is the goal. Some things in the demo don't look right as a result of this- those are bugs that should be fixed. It's more important to have our development environment reflect those bugs then to continue testing against live and having "it works on my system" issues.