### PR TITLE
fix: Disable `no-descending-specificity` lint rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["stylelint-config-standard-scss"]
+  "extends": ["stylelint-config-standard-scss"],
+  "rules": {
+    "no-descending-specificity": null
+  }
 }


### PR DESCRIPTION
Disables the Stylelint `no-descending-specificity` rule because:

1. Stylelint cannot access our HTML code and therefore can only interpret usage from our CSS; and
2. This rule is more applicable to the old ways of writing CSS where selectors and descending specificity was more or less the way to go. Considering that we use SCSS and that we have much better and more modern methods of selecting elements, this rule is, in my opinion, a big time waster when trying to make the linter happy. This rule is outdated.

In my PRs on this project, I've spent more time than I should trying to make the linter happy by moving around blocks of code that I know will work. Moreover, you often find yourself in a situation where moving one block above another, as the linter suggests, just causes it to throw another error telling you to move it back. While I could refactor some of my UI by adding classes and writing CSS in the old style, this basically eliminates one of the biggest and most compelling features of SCSS and is, therefore, in my opinion, a major impediment to progress in this context.