### PR TITLE
feat(`AccessCodeTable` & `DeviceTable`) - truncate long names

### DIFF
--- a/.storybook/seed-fake.js
+++ b/.storybook/seed-fake.js
@@ -74,7 +74,7 @@ export const seedFake = (db) => {
   db.addAccessCode({
     device_id: device1.device_id,
     workspace_id: ws2.workspace_id,
-    name: "John's Front Door Code",
+    name: "John's House main Front Door Code Version Two",
     code: '1234',
     common_code_key: null,
     type: 'ongoing',

--- a/src/lib/ui/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/ui/AccessCodeTable/AccessCodeTable.tsx
@@ -107,7 +107,7 @@ function AccessCodeRow(props: {
         </div>
       </TableCell>
       <TableCell className='seam-name-cell'>
-        <Title>{accessCode.name}</Title>
+        <Title className='seam-truncated-text'>{accessCode.name}</Title>
         <CodeDetails accessCode={accessCode} />
       </TableCell>
       <TableCell className='seam-action-cell'>

--- a/src/lib/ui/AccessCodeTable/CodeDetails.tsx
+++ b/src/lib/ui/AccessCodeTable/CodeDetails.tsx
@@ -9,7 +9,7 @@ export function CodeDetails(props: { accessCode: AccessCode }): JSX.Element {
 
   return (
     <div className='seam-code-details'>
-      Unit 110
+      <span className='seam-device-name seam-truncated-text'>Unit 110</span>
       <DotDivider />
       <Duration accessCode={accessCode} />
       <DotDivider />

--- a/src/lib/ui/DeviceTable/DeviceTable.tsx
+++ b/src/lib/ui/DeviceTable/DeviceTable.tsx
@@ -119,7 +119,7 @@ function DeviceRow(props: {
         <DeviceImage device={device} />
       </TableCell>
       <TableCell className='seam-body-cell'>
-        <Title>{device.properties.name}</Title>
+        <Title className='seam-truncated-text'>{device.properties.name}</Title>
         <div className='seam-bottom'>
           <span className='seam-device-model'>{deviceModel}</span>
           <div className='seam-device-statuses'>

--- a/src/lib/ui/types.ts
+++ b/src/lib/ui/types.ts
@@ -2,3 +2,4 @@ import type { HTMLAttributes, HtmlHTMLAttributes } from 'react'
 
 export type DivProps = HTMLAttributes<HTMLDivElement>
 export type ButtonProps = HtmlHTMLAttributes<HTMLButtonElement>
+export type SpanProps = HtmlHTMLAttributes<HTMLSpanElement>

--- a/src/lib/ui/typography/Title.tsx
+++ b/src/lib/ui/typography/Title.tsx
@@ -1,5 +1,15 @@
-import type { PropsWithChildren } from 'react'
+import classNames from 'classnames'
 
-export function Title({ children }: PropsWithChildren): JSX.Element {
-  return <span className='seam-title'>{children}</span>
+import type { SpanProps } from 'lib/ui/types.js'
+
+export function Title({
+  children,
+  className,
+  ...props
+}: SpanProps): JSX.Element {
+  return (
+    <span className={classNames('seam-title', className)} {...props}>
+      {children}
+    </span>
+  )
 }

--- a/src/styles/_access-code-table.scss
+++ b/src/styles/_access-code-table.scss
@@ -26,11 +26,22 @@
         justify-content: center;
         align-items: flex-start;
         gap: 2px;
+        overflow: hidden;
+
+        .seam-title {
+          max-width: 380px;
+        }
 
         .seam-code-details {
           font-size: 14px;
           line-height: 134%;
           color: colors.$text-gray-1;
+          display: flex;
+
+          .seam-device-name {
+            max-width: 190px;
+            width: auto;
+          }
 
           .seam-dot-divider {
             margin: 0 4px;

--- a/src/styles/_device-table.scss
+++ b/src/styles/_device-table.scss
@@ -23,6 +23,10 @@
         gap: 2px;
         overflow: hidden;
 
+        .seam-title {
+          max-width: 380px;
+        }
+
         .seam-bottom {
           display: flex;
           justify-content: space-between;

--- a/src/styles/_device-table.scss
+++ b/src/styles/_device-table.scss
@@ -21,6 +21,7 @@
         justify-content: center;
         align-items: flex-start;
         gap: 2px;
+        overflow: hidden;
 
         .seam-bottom {
           display: flex;

--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -35,10 +35,21 @@
   }
 }
 
+@mixin truncated-text {
+  .seam-truncated-text {
+    display: block;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
 @mixin all {
   @include headers;
   @include caption;
   @include danger-text;
   @include font-family;
   @include defaults;
+  @include truncated-text;
 }


### PR DESCRIPTION
Closes #104 

![CleanShot 2023-05-25 at 18 37 43](https://github.com/seamapi/react/assets/11449462/74e135f3-db93-4cfa-a8a6-2a1aaebc27c0)
![CleanShot 2023-05-25 at 18 39 51@2x](https://github.com/seamapi/react/assets/11449462/a20ef671-345e-40be-9c9e-f88babdfa77d)
![CleanShot 2023-05-25 at 18 40 40@2x](https://github.com/seamapi/react/assets/11449462/db8fb42e-c302-46b8-b726-2062185321b4)

![CleanShot 2023-05-25 at 18 52 53@2x](https://github.com/seamapi/react/assets/11449462/4459b4a3-6792-4286-8adf-6715dc3f8b4f)
