### PR TITLE
fix(`AccessCodeTable`): device name was always hardcoded as Unit 110

### DIFF
--- a/src/lib/ui/AccessCodeTable/CodeDetails.tsx
+++ b/src/lib/ui/AccessCodeTable/CodeDetails.tsx
@@ -1,15 +1,18 @@
 import { DateTime } from 'luxon'
 import type { AccessCode } from 'seamapi'
 
+import { useDevice } from 'lib/index.js'
+
 import { DotDivider } from 'lib/ui/layout/DotDivider.js'
 import { useIsDateInPast } from 'lib/use-is-date-in-past.js'
 
 export function CodeDetails(props: { accessCode: AccessCode }): JSX.Element {
   const { accessCode } = props
+  const { device } = useDevice({ device_id: accessCode.device_id })
 
   return (
     <div className='seam-code-details'>
-      Unit 110
+      {device?.properties.name}
       <DotDivider />
       <Duration accessCode={accessCode} />
       <DotDivider />


### PR DESCRIPTION
### Before

Everything was Unit 110, everywhere.

<img width="605" alt="CleanShot 2023-05-25 at 19 00 09@2x" src="https://github.com/seamapi/react/assets/11449462/862ff8af-590d-4e46-b0ce-681d3d33a1a1">

### After

<img width="594" alt="CleanShot 2023-05-25 at 19 00 17@2x" src="https://github.com/seamapi/react/assets/11449462/b014f30a-4b0e-4d2c-9d08-656749175021">
