### PR TITLE
docs: Proxy unpkg

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -42,7 +42,7 @@ const preview: Preview = {
       defaultValue: useFake
         ? // special hack for chromatic ui reviews that don't run the fake
           window?.location?.href.includes('chromatic')
-          ? 'https://seam-react.vercel.app/api'
+          ? 'https://react.seam.co/api'
           : '/api'
         : process.env['STORYBOOK_SEAM_ENDPOINT'],
     },

--- a/README.md
+++ b/README.md
@@ -69,10 +69,7 @@ import '@seamapi/react/index.css'
 or place the following in the `<head>` tag:
 
 ```html
-<link
-  rel="stylesheet"
-  href="https://react.seam.co/v/^1.0.0/index.min.css"
-/>
+<link rel="stylesheet" href="https://react.seam.co/v/^1.0.0/index.min.css" />
 ```
 
 > You can replace the version string above with the exact version of this package used by your application.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Components are styled with plain Cascading Style Sheets (CSS).
 All styles are prefixed with `seam-` to avoid name collisions.
 
 By default, the `SeamProvider` will inject a link tag into the document head to load the CSS.
-This may be disabled with the `disableCssInjection` prop.
-If you prefer to manually load the CSS, either import it using a supported bundler with
+If you prefer to manually load the CSS,
+this behavior may be disabled with the `disableCssInjection` prop.
+Then, either import the CSS using a supported bundler with
 
 ```ts
 import '@seamapi/react/index.css'
@@ -83,8 +84,9 @@ or place the following in the `<head>` tag:
 The components are optimized for use with [Source Sans Pro], but will fallback to other system sans-serif fonts.
 
 By default, the `SeamProvider` will inject a link tag into the document head to load the font.
-This may be disabled with the `disableFontInjection` prop.
-If you prefer to manually provide the font, load it from Google Fonts by placing the following in the `<head>` tag:
+If you prefer to manually provide the font,
+this behavior may be disabled with the `disableFontInjection` prop.
+Then, load it from Google Fonts by placing the following in the `<head>` tag:
 
 ```html
 <link

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ or place the following in the `<head>` tag:
 ```html
 <link
   rel="stylesheet"
-  href="https://react.seam.co/dist/^1.0.0/index.min.css"
+  href="https://react.seam.co/v/^1.0.0/index.min.css"
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ import '@seamapi/react/index.css'
 
 or place the following in the `<head>` tag:
 
+> You should replace the version string below with the exact version of this package used by your application.
+
 ```html
 <link rel="stylesheet" href="https://react.seam.co/v/^1.0.0/index.min.css" />
 ```
-
-> You can replace the version string above with the exact version of this package used by your application.
 
 ### Fonts
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ with everything you need to get started with [Seam].
 Play with them live in the [Storybook]!
 
 [Seam]: https://www.seam.co/
-[Storybook]: https://seam-react.vercel.app/
+[Storybook]: https://react.seam.co/
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,41 @@ export const App = () => {
 
 [Seam Console]: https://console.seam.co/
 
+### Styles
+
+> CSS is automatically included unless using `<SeamProvider disableCssInjection />`.
+
+Components are styled with plain Cascading Style Sheets (CSS).
+All styles are prefixed with `seam-` to avoid name collisions.
+
+By default, the `SeamProvider` will inject a link tag into the document head to load the CSS.
+This may be disabled with the `disableCssInjection` prop.
+If you prefer to manually load the CSS, either import it using a supported bundler with
+
+```ts
+import '@seamapi/react/index.css'
+```
+
+or place the following in the `<head>` tag:
+
+```html
+<link
+  rel="stylesheet"
+  href="https://react.seam.co/dist/^1.0.0/index.min.css"
+/>
+```
+
+> You can replace the version string above with the exact version of this package used by your application.
+
 ### Fonts
 
-> The font is automatically included unless you specify `disableFontInjection` in `<SeamProvider />`
+> Fonts are automatically included unless using `<SeamProvider disableFontInjection />`.
 
 The components are optimized for use with [Source Sans Pro], but will fallback to other system sans-serif fonts.
-Load the font from Google Fonts by placing the following in the `<head>` tag:
+
+By default, the `SeamProvider` will inject a link tag into the document head to load the font.
+This may be disabled with the `disableFontInjection` prop.
+If you prefer to manually provide the font, load it from Google Fonts by placing the following in the `<head>` tag:
 
 ```html
 <link

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ import '@seamapi/react/index.css'
 
 or place the following in the `<head>` tag:
 
-> You should replace the version string below with the exact version of this package used by your application.
+> You must match the version string below with the exact version of this package used by your application.
 
 ```html
-<link rel="stylesheet" href="https://react.seam.co/v/^1.0.0/index.min.css" />
+<link rel="stylesheet" href="https://react.seam.co/v/1.0.0/index.min.css" />
 ```
 
 ### Fonts

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,9 @@
   "cleanUrls": true,
   "rewrites": [
     {
+      "source": "/dist/:version/:asset*",
+      "destination": "https://www.unpkg.com/@seamapi/react@:version/:asset"
+    }, {
       "source": "/api/:fakepath*",
       "destination": "/api/fakepath"
     }

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
   "cleanUrls": true,
   "rewrites": [
     {
-      "source": "/dist/:version/:asset*",
+      "source": "/v/:version/:asset*",
       "destination": "https://www.unpkg.com/@seamapi/react@:version/:asset"
     }, {
       "source": "/api/:fakepath*",

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,8 @@
     {
       "source": "/v/:version/:asset*",
       "destination": "https://www.unpkg.com/@seamapi/react@:version/:asset"
-    }, {
+    },
+    {
       "source": "/api/:fakepath*",
       "destination": "/api/fakepath"
     }


### PR DESCRIPTION
- Allows us to provide a stable URL for assets independent of the backing CDN.
- Font's still need to come from Google Fonts as re-hosting that is non-trivial (also not versioned, so no need to rehost).
- Once this is on main, can update the internal URL and fix the version replacement at build time.