### PR TITLE
Connect account button

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ $ npm install @seamapi/react
 3. Drop in Seam Components.
 
 ```ts
-import { SeamProvider, DeviceTable } from '@seamapi/react'
+import { ConnectAccountButton, DeviceTable, SeamProvider } from '@seamapi/react'
 
 export const App = () => {
   return (
     <SeamProvider publishableKey='your_publishable_key'>
       <main>
         <h1>My App</h1>
+        <ConnectAccountButton />
         <DeviceTable />
       </main>
     </SeamProvider>

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ export const App = () => {
 
 ```html
 <body>
+  <seam-connect-account-button
+    publishable-key="your_publishable_key"
+  ></seam-connect-account-button>
   <seam-device-table publishable-key="your_publishable_key"></seam-device-table>
   <script
     type="module"

--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -1,4 +1,9 @@
-import { DeviceTable, SeamProvider, SupportedDeviceTable } from '@seamapi/react'
+import {
+  ConnectAccountButton,
+  DeviceTable,
+  SeamProvider,
+  SupportedDeviceTable,
+} from '@seamapi/react'
 
 export const App = (): JSX.Element => {
   return (
@@ -10,6 +15,7 @@ export const App = (): JSX.Element => {
     >
       <main>
         <h1>Seam Components</h1>
+        <ConnectAccountButton />
         <DeviceTable />
         <h2>Supported Devices</h2>
         <SupportedDeviceTable />

--- a/examples/web-components/index.html
+++ b/examples/web-components/index.html
@@ -7,6 +7,11 @@
   </head>
   <body>
     <main>
+      <seam-connect-account-button
+        publishable-key="%SEAM_PUBLISHABLE_KEY%"
+        user-identifier-key="%SEAM_USER_IDENTIFIER_KEY%"
+        disable-css-injection="true"
+      ></seam-connect-account-button>
       <seam-device-table
         publishable-key="%SEAM_PUBLISHABLE_KEY%"
         user-identifier-key="%SEAM_USER_IDENTIFIER_KEY%"

--- a/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.element.ts
+++ b/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.element.ts
@@ -1,0 +1,11 @@
+import type { ElementProps } from 'lib/element.js'
+
+import type { ConnectAccountButtonProps } from './ConnectAccountButton.js'
+
+export const name = 'seam-connect-account-button'
+
+export const props: ElementProps<ConnectAccountButtonProps> = {
+  className: 'string',
+}
+
+export { ConnectAccountButton as Component } from './ConnectAccountButton.js'

--- a/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.stories.tsx
+++ b/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { ConnectAccountButton } from 'lib/seam/components/ConnectAccountButton/ConnectAccountButton.js'
+
+const meta: Meta<typeof ConnectAccountButton> = {
+  title: 'Example/ConnectAccountButton',
+  component: ConnectAccountButton,
+  tags: ['autodocs'],
+}
+
+export default meta
+
+type Story = StoryObj<typeof ConnectAccountButton>
+
+export const Content: Story = {}

--- a/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.tsx
+++ b/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.tsx
@@ -1,8 +1,7 @@
 import { useCallback } from 'react'
 
+import { useCreateConnectWebview } from 'lib/seam/connect-webviews/use-create-connect-webview.js'
 import { Button } from 'lib/ui/Button.js'
-
-import { useCreateConnectWebview } from '../../../../hooks.js'
 
 export interface ConnectAccountButtonProps {
   className?: string

--- a/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.tsx
+++ b/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { TextButton } from 'lib/ui/TextButton.js'
+import { Button } from 'lib/ui/Button.js'
 
 import { useCreateConnectWebview } from '../../../../hooks.js'
 
@@ -25,13 +25,14 @@ export function ConnectAccountButton({
   }, [mutate, url])
 
   return (
-    <TextButton
+    <Button
+      size='small'
       onClick={handleClick}
       className={className}
       disabled={isLoading}
     >
       {t.connectAccount}
-    </TextButton>
+    </Button>
   )
 }
 

--- a/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.tsx
+++ b/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.tsx
@@ -1,0 +1,40 @@
+import { useCallback } from 'react'
+
+import { TextButton } from 'lib/ui/TextButton.js'
+
+import { useCreateConnectWebview } from '../../../../hooks.js'
+
+export interface ConnectAccountButtonProps {
+  className?: string
+}
+
+export function ConnectAccountButton({
+  className,
+}: ConnectAccountButtonProps = {}): JSX.Element {
+  const { isLoading, mutate } = useCreateConnectWebview({
+    willNavigateToWebview: true,
+  })
+
+  const url = window.location.href
+  const handleClick = useCallback(() => {
+    mutate({
+      accepted_providers: [],
+      custom_redirect_url: url,
+      custom_redirect_failure_url: url,
+    })
+  }, [mutate, url])
+
+  return (
+    <TextButton
+      onClick={handleClick}
+      className={className}
+      disabled={isLoading}
+    >
+      {t.connectAccount}
+    </TextButton>
+  )
+}
+
+const t = {
+  connectAccount: 'Connect Account',
+}

--- a/src/lib/seam/components/elements.ts
+++ b/src/lib/seam/components/elements.ts
@@ -1,5 +1,6 @@
 export * as AccessCodeDetails from './AccessCodeDetails/AccessCodeDetails.element.js'
 export * as AccessCodeTable from './AccessCodeTable/AccessCodeTable.element.js'
+export * as ConnectAccountButton from './ConnectAccountButton/ConnectAccountButton.element.js'
 export * as DeviceDetails from './DeviceDetails/DeviceDetails.element.js'
 export * as DeviceTable from './DeviceTable/DeviceTable.element.js'
 export * as SupportedDeviceTable from './SupportedDeviceTable/SupportedDeviceTable.element.js'

--- a/src/lib/seam/components/index.ts
+++ b/src/lib/seam/components/index.ts
@@ -1,5 +1,6 @@
 export * from './AccessCodeDetails/AccessCodeDetails.js'
 export * from './AccessCodeTable/AccessCodeTable.js'
+export * from './ConnectAccountButton/ConnectAccountButton.js'
 export * from './DeviceDetails/DeviceDetails.js'
 export * from './DeviceTable/DeviceTable.js'
 export * from './SupportedDeviceTable/SupportedDeviceTable.js'

--- a/src/lib/seam/connect-webviews/use-create-connect-webview.ts
+++ b/src/lib/seam/connect-webviews/use-create-connect-webview.ts
@@ -2,6 +2,7 @@ import { useMutation, type UseMutationResult } from '@tanstack/react-query'
 import type {
   ConnectWebview,
   ConnectWebviewCreateRequest,
+  ConnectWebviewCreateResponse,
   SeamError,
 } from 'seamapi'
 
@@ -19,7 +20,11 @@ export function useCreateConnectWebview(
   const { willNavigateToWebview = false } = params ?? {}
   const { client } = useSeamClient()
 
-  return useMutation({
+  return useMutation<
+    ConnectWebviewCreateResponse['connect_webview'],
+    SeamError,
+    UseCreateConnectWebviewMutationParams
+  >({
     mutationFn: async (
       mutationParams: UseCreateConnectWebviewMutationParams
     ) => {

--- a/src/lib/seam/connect-webviews/use-create-connect-webview.ts
+++ b/src/lib/seam/connect-webviews/use-create-connect-webview.ts
@@ -1,0 +1,38 @@
+import { useMutation, type UseMutationResult } from '@tanstack/react-query'
+import type {
+  ConnectWebview,
+  ConnectWebviewCreateRequest,
+  SeamError,
+} from 'seamapi'
+
+import { useSeamClient } from 'lib/seam/use-seam-client.js'
+
+export interface UseCreateConnectWebviewParams {
+  willNavigateToWebview?: boolean
+}
+
+export type UseCreateConnectWebviewMutationParams = ConnectWebviewCreateRequest
+
+export function useCreateConnectWebview(
+  params?: UseCreateConnectWebviewParams
+): UseMutationResult<ConnectWebview, SeamError, ConnectWebviewCreateRequest> {
+  const { willNavigateToWebview = false } = params ?? {}
+  const { client } = useSeamClient()
+
+  return useMutation({
+    mutationFn: async (
+      mutationParams: UseCreateConnectWebviewMutationParams
+    ) => {
+      if (client == null) {
+        throw new Error('Missing seam client')
+      }
+
+      return await client.connectWebviews.create(mutationParams)
+    },
+    onSuccess: ({ url }) => {
+      if (willNavigateToWebview) {
+        globalThis.location.href = url
+      }
+    },
+  })
+}

--- a/src/lib/seam/connect-webviews/use-create-connect-webview.ts
+++ b/src/lib/seam/connect-webviews/use-create-connect-webview.ts
@@ -35,7 +35,7 @@ export function useCreateConnectWebview(
       return await client.connectWebviews.create(mutationParams)
     },
     onSuccess: ({ url }) => {
-      if (willNavigateToWebview) {
+      if (willNavigateToWebview && url != null) {
         globalThis.location.href = url
       }
     },

--- a/src/lib/seam/connect-webviews/use-create-connect-webview.ts
+++ b/src/lib/seam/connect-webviews/use-create-connect-webview.ts
@@ -14,10 +14,13 @@ export interface UseCreateConnectWebviewParams {
 
 export type UseCreateConnectWebviewMutationParams = ConnectWebviewCreateRequest
 
-export function useCreateConnectWebview(
-  params?: UseCreateConnectWebviewParams
-): UseMutationResult<ConnectWebview, SeamError, ConnectWebviewCreateRequest> {
-  const { willNavigateToWebview = false } = params ?? {}
+export function useCreateConnectWebview({
+  willNavigateToWebview = false,
+}: UseCreateConnectWebviewParams = {}): UseMutationResult<
+  ConnectWebview,
+  SeamError,
+  ConnectWebviewCreateRequest
+> {
   const { client } = useSeamClient()
 
   return useMutation<

--- a/src/lib/seam/devices/use-toggle-lock.ts
+++ b/src/lib/seam/devices/use-toggle-lock.ts
@@ -25,7 +25,7 @@ export function useToggleLock({
   const { client } = useSeamClient()
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useMutation<{ actionAttempt: ActionAttempt }, SeamError>({
     mutationFn: async () => {
       if (client == null) {
         throw new Error('Missing seam client')

--- a/src/lib/seam/index.ts
+++ b/src/lib/seam/index.ts
@@ -1,5 +1,6 @@
 export * from './access-codes/use-access-code.js'
 export * from './access-codes/use-access-codes.js'
+export * from './connect-webviews/use-create-connect-webview.js'
 export * from './device-models/use-device-models.js'
 export * from './devices/use-device.js'
 export * from './devices/use-devices.js'


### PR DESCRIPTION
This is the missing button to make all of the publishable key examples work without needing to setup the the client session first with a separate backend call.

- feat: Add useCreateConnectWebview
- feat: Add ConnectAccountButton
- Document ConnectAccountButton
- Add seam-connect-account-button
<img width="1106" alt="image" src="https://github.com/seamapi/react/assets/721372/4cd05906-c9ee-481a-b9a6-298602bab660">

