### PR TITLE
OSS friendly workflow triggers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,9 @@ name: Check
 on:
   push:
     branches:
+      - main
+  pull_request:
+    branches:
       - '**'
 
 jobs:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,6 +4,9 @@ name: Chromatic
 on:
   push:
     branches:
+      - main
+  pull_request:
+    branches:
       - '**'
 
 jobs:
@@ -43,7 +46,7 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: de095a2cb27a
           buildScriptName: storybook:build
         env:
           STORYBOOK_SEAM_ENDPOINT: ${{ steps.seam_endpoint.outputs.url }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,8 +2,8 @@
 name: Format
 
 on:
-  pull_request:
-    branches:
+  push:
+    branches-ignore:
       - main
   workflow_dispatch: {}
 

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -2,8 +2,8 @@
 name: Generate
 
 on:
-  pull_request:
-    branches:
+  push:
+    branches-ignore:
       - main
   workflow_dispatch: {}
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,6 @@ The following repository secrets must be set on [GitHub Actions]:
 - `GPG_PRIVATE_KEY`: The GitHub bot user's [GPG private key].
 - `GPG_PASSPHRASE`: The GitHub bot user's GPG passphrase.
 - `VERCEL_ACCESS_TOKEN`: The Vercel project token.
-- `CHROMATIC_PROJECT_TOKEN`: The Chromatic project token.
 
 The following repository variables must be set on [GitHub Actions]:
 


### PR DESCRIPTION
- ci: Adjust workflow triggers for contributors
  - Needed so workflows with secrets do not run and fail on forks. ref: https://github.com/seamapi/ruby/pull/51
- Allow chromatic to run on forks
    - See https://www.chromatic.com/docs/custom-ci-provider#run-chromatic-on-external-forks-of-open-source-projects
