### PR TITLE
feat: Add disableFilter and deprecate cannotFilter

### DIFF
--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDevice.stories.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDevice.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof SupportedDeviceTable>
 export const Content: Story = {}
 
 export const NoFilter: Story = {
-  render: (props) => <SupportedDeviceTable {...props} cannotFilter />,
+  render: (props) => <SupportedDeviceTable {...props} disableFilter />,
 }
 
 export const InsideModal: Story = {

--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceTable.element.ts
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceTable.element.ts
@@ -6,6 +6,7 @@ export const name = 'seam-supported-device-table'
 
 export const props: ElementProps<SupportedDeviceTableProps> = {
   cannotFilter: 'boolean',
+  disableFilter: 'boolean',
   className: 'string',
 }
 

--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceTable.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceTable.tsx
@@ -15,7 +15,7 @@ export interface SupportedDeviceTableProps {
 }
 
 export function SupportedDeviceTable({
-  disableFilter,
+  disableFilter = false,
   cannotFilter,
   className,
 }: SupportedDeviceTableProps = {}): JSX.Element {
@@ -26,8 +26,7 @@ export function SupportedDeviceTable({
     brand: null,
   })
 
-  const hideFilter =
-    cannotFilter == null ? disableFilter ?? false : cannotFilter ?? false
+  const hideFilter = cannotFilter ?? disableFilter
 
   return (
     <div

--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceTable.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceTable.tsx
@@ -6,12 +6,17 @@ import { SupportedDeviceFilterArea } from 'lib/seam/components/SupportedDeviceTa
 import type { DeviceModelFilters } from 'lib/seam/components/SupportedDeviceTable/use-filtered-device-models.js'
 
 export interface SupportedDeviceTableProps {
+  disableFilter?: boolean
+  /**
+   * @deprecated Use disableFilter.
+   */
   cannotFilter?: boolean
   className?: string
 }
 
 export function SupportedDeviceTable({
-  cannotFilter = false,
+  disableFilter,
+  cannotFilter,
   className,
 }: SupportedDeviceTableProps = {}): JSX.Element {
   const [filterValue, setFilterValue] = useState('')
@@ -21,6 +26,9 @@ export function SupportedDeviceTable({
     brand: null,
   })
 
+  const hideFilter =
+    cannotFilter == null ? disableFilter ?? false : cannotFilter ?? false
+
   return (
     <div
       className={classNames(
@@ -28,7 +36,7 @@ export function SupportedDeviceTable({
         className
       )}
     >
-      {!cannotFilter && (
+      {!hideFilter && (
         <SupportedDeviceFilterArea
           filterValue={filterValue}
           setFilterValue={setFilterValue}


### PR DESCRIPTION
Prop convention is moving to `disable/enable` prefixes, see e.g., https://github.com/seamapi/react/issues/238