### PR TITLE
fix: Update `Alert` style to match design spec

### DIFF
--- a/src/lib/ui/Alert/Alert.tsx
+++ b/src/lib/ui/Alert/Alert.tsx
@@ -24,12 +24,14 @@ export function Alert(props: AlertProps): JSX.Element {
       className={classNames('seam-alert', `seam-${variant}-alert`, className)}
     >
       <div className='seam-alert-content'>
-        <div className='seam-alert-icon'>
-          {variant === 'warning' ? (
-            <TriangleWarningIcon />
-          ) : (
-            <ExclamationCircleIcon />
-          )}
+        <div className='seam-alert-icon-wrap'>
+          <div className='seam-alert-icon'>
+            {variant === 'warning' ? (
+              <TriangleWarningIcon />
+            ) : (
+              <ExclamationCircleIcon />
+            )}
+          </div>
         </div>
         <div className='seam-alert-message-wrap'>
           <p className='seam-alert-message'>{message}</p>

--- a/src/styles/_alert.scss
+++ b/src/styles/_alert.scss
@@ -1,6 +1,7 @@
 @use './colors';
 
 @mixin all {
+
   // Alerts
   .seam-alerts {
     width: 100%;
@@ -13,12 +14,16 @@
     &.seam-alerts-space-top {
       margin-top: 16px;
     }
+
+    &.seam-alerts-padded {
+      padding: 0 16px 24px;
+    }
   }
 
   // Alert
   .seam-alert {
     width: 100%;
-    min-height: 70px;
+    min-height: 54px;
     padding: 8px 16px;
     border-radius: 8px;
     display: flex;
@@ -68,6 +73,11 @@
       margin-top: 16px;
     }
 
+    .seam-alert-icon-wrap {
+      padding: 7px 8px;
+      padding-left: 0;
+    }
+
     .seam-alert-icon {
       width: 24px;
       height: 24px;
@@ -76,12 +86,13 @@
     .seam-alert-content {
       display: flex;
       justify-content: flex-start;
-      align-items: center;
+      align-items: flex-start;
       flex-direction: row;
-      gap: 8px;
     }
 
     .seam-alert-message-wrap {
+      padding: 8px 0;
+
       .seam-alert-message {
         font-size: 14px;
         font-weight: 400;
@@ -91,7 +102,7 @@
     }
   }
 
-  @media only screen and (width <= 500px) {
+  @media only screen and (width <=500px) {
     .seam-alert {
       justify-content: flex-start;
       flex-direction: column;

--- a/src/styles/_alert.scss
+++ b/src/styles/_alert.scss
@@ -1,7 +1,6 @@
 @use './colors';
 
 @mixin all {
-
   // Alerts
   .seam-alerts {
     width: 100%;

--- a/src/styles/_alert.scss
+++ b/src/styles/_alert.scss
@@ -13,10 +13,6 @@
     &.seam-alerts-space-top {
       margin-top: 16px;
     }
-
-    &.seam-alerts-padded {
-      padding: 0 16px 24px;
-    }
   }
 
   // Alert


### PR DESCRIPTION
Updates the styling of the `Alert` component to match the updated design spec (not sure when it changed). This will be used in #243.

---

![Arc 2023-06-27 at 19 20 26@2x](https://github.com/seamapi/react/assets/87919558/7207607a-3096-4b9c-a86f-aae00f0ec6c7)