### PR TITLE
ci: Do not set STORYBOOK_SEAM_ENDPOINT on vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,6 @@ The following environment variables must be set on [Vercel]:
 
 - `SEAM_PUBLISHABLE_KEY`: The Seam publishable key to use with the examples.
 - `SEAM_USER_IDENTIFIER_KEY`: The Seam user identifer key to use with the examples..
-- `STORYBOOK_SEAM_ENDPOINT`: The Seam endpoint to use with Storybook.
 - `STORYBOOK_SEAM_PUBLISHABLE_KEY`: The Seam publishable key to use with Storybook.
 - `STORYBOOK_SEAM_USER_IDENTIFIER_KEY`: The Seam user identifer key to use with Storybook.
 


### PR DESCRIPTION
This should have been done eariler so the preview env always uses the fake api on the preview env not main.