### PR TITLE
Always extend from PropsWithChildren

### DIFF
--- a/src/lib/seam/SeamProvider.tsx
+++ b/src/lib/seam/SeamProvider.tsx
@@ -25,10 +25,11 @@ export interface SeamContext {
   clientSessionToken?: string | undefined
 }
 
-export type SeamProviderProps =
+export type SeamProviderProps = PropsWithChildren<
   | SeamProviderPropsWithClient
   | SeamProviderPropsWithPublishableKey
   | SeamProviderPropsWithClientSessionToken
+>
 
 export interface SeamProviderPropsWithClient extends SeamProviderBaseProps {
   client: Seam
@@ -65,7 +66,7 @@ export function SeamProvider({
   unminifiyCss = false,
   queryClient,
   ...props
-}: PropsWithChildren<SeamProviderProps>): JSX.Element {
+}: SeamProviderProps): JSX.Element {
   useSeamStyles({ disabled: disableCssInjection, unminified: unminifiyCss })
   useSeamFont({ disabled: disableFontInjection })
 

--- a/src/lib/ui/Alert/Alerts.tsx
+++ b/src/lib/ui/Alert/Alerts.tsx
@@ -3,14 +3,12 @@ import type { PropsWithChildren } from 'react'
 
 import { Alert, type AlertProps } from 'lib/ui/Alert/Alert.js'
 
-interface AlertsProps {
+interface AlertsProps extends PropsWithChildren {
   alerts?: AlertProps[]
   className?: string
 }
 
-export function Alerts(
-  props: PropsWithChildren<AlertsProps>
-): JSX.Element | null {
+export function Alerts(props: AlertsProps): JSX.Element | null {
   const { alerts, children, className } = props
 
   if (alerts?.length === 0) return null

--- a/src/lib/ui/Button.tsx
+++ b/src/lib/ui/Button.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import type { MouseEventHandler, PropsWithChildren } from 'react'
 
-interface ButtonProps {
+interface ButtonProps extends PropsWithChildren {
   variant?: 'solid' | 'outline' | 'neutral'
   size?: 'small' | 'medium' | 'large'
   disabled?: boolean
@@ -16,7 +16,7 @@ export function Button({
   disabled = false,
   onClick,
   className,
-}: PropsWithChildren<ButtonProps>): JSX.Element {
+}: ButtonProps): JSX.Element {
   return (
     <button
       className={classNames(

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 
-export interface MenuProps {
+export interface MenuProps extends PropsWithChildren {
   verticalOffset?: number
   horizontalOffset?: number
   edgeOffset?: number
@@ -38,7 +38,7 @@ export function Menu({
   children,
   renderButton,
   backgroundProps,
-}: PropsWithChildren<MenuProps>): JSX.Element | null {
+}: MenuProps): JSX.Element | null {
   const { Provider } = menuContext
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [documentEl, setDocumentEl] = useState<null | Element>(null)

--- a/src/lib/ui/Menu/MenuItem.tsx
+++ b/src/lib/ui/Menu/MenuItem.tsx
@@ -2,14 +2,11 @@ import type { PropsWithChildren } from 'react'
 
 import { useMenu } from 'lib/ui/Menu/Menu.js'
 
-interface MenuItemProps {
+interface MenuItemProps extends PropsWithChildren {
   onClick: () => void
 }
 
-export function MenuItem({
-  onClick,
-  children,
-}: PropsWithChildren<MenuItemProps>): JSX.Element {
+export function MenuItem({ onClick, children }: MenuItemProps): JSX.Element {
   const { close: closeMenu } = useMenu()
 
   return (

--- a/src/lib/ui/Menu/MoreActionsMenu.tsx
+++ b/src/lib/ui/Menu/MoreActionsMenu.tsx
@@ -4,14 +4,14 @@ import { DotsEllipsisMoreIcon } from 'lib/icons/DotsEllipsisMore.js'
 import { IconButton } from 'lib/ui/IconButton.js'
 import { Menu, type MenuProps } from 'lib/ui/Menu/Menu.js'
 
-interface MoreActionsMenuProps {
+interface MoreActionsMenuProps extends PropsWithChildren {
   menuProps?: Partial<MenuProps>
 }
 
 export function MoreActionsMenu({
   children,
   menuProps,
-}: PropsWithChildren<MoreActionsMenuProps>): JSX.Element {
+}: MoreActionsMenuProps): JSX.Element {
   return (
     <Menu
       renderButton={({ onOpen }) => (


### PR DESCRIPTION
- fix: SeamProviderProps now includes children
- refactor: Always extend PropsWithChildren

Props to @mikewuu for figuring this one out: https://github.com/seamapi/react/pull/271#discussion_r1260448184