### PR TITLE
Test DeviceTable loads data

### DIFF
--- a/src/lib/seam/components/DeviceTable/DeviceTable.test.tsx
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.test.tsx
@@ -4,5 +4,5 @@ import { DeviceTable } from './DeviceTable.js'
 
 test('DeviceTable', async () => {
   render(<DeviceTable />)
-  await screen.findByText('...')
+  await screen.findByText('Front Door')
 })

--- a/src/lib/seam/use-seam-client.ts
+++ b/src/lib/seam/use-seam-client.ts
@@ -39,6 +39,7 @@ export function useSeamClient(): {
       if (clientSessionToken != null) {
         return new Seam({
           ...clientOptions,
+          apiKey: undefined,
           clientSessionToken,
         })
       }
@@ -61,6 +62,7 @@ export function useSeamClient(): {
 
       return new Seam({
         ...clientOptions,
+        apiKey: undefined,
         clientSessionToken: res.client_session.token,
       })
     },

--- a/test/fixtures/react.tsx
+++ b/test/fixtures/react.tsx
@@ -1,4 +1,5 @@
 import { SeamProvider } from '@seamapi/react'
+import { QueryClient } from '@tanstack/react-query'
 import { render } from '@testing-library/react'
 import type { PropsWithChildren } from 'react'
 
@@ -13,26 +14,45 @@ declare global {
   var JEST_SEAM_CLIENT_SESSION_TOKEN_2: string
 }
 
-function Providers({ children }: PropsWithChildren): JSX.Element {
-  return (
-    <SeamProvider
-      endpoint={globalThis.JEST_SEAM_ENDPOINT}
-      publishableKey={globalThis.JEST_SEAM_PUBLISHABLE_KEY_1}
-      userIdentifierKey='some_user'
-      disableCssInjection
-      disableFontInjection
-    >
-      {children}
-    </SeamProvider>
-  )
-}
-
 type Render = typeof render
 
 const customRender = (
   ui: Parameters<Render>[0],
   options?: Parameters<Render>[1]
-): ReturnType<Render> => render(ui, { wrapper: Providers, ...options })
+): ReturnType<Render> => {
+  const queryClient = createQueryClient()
+  const Providers = createProviders({ queryClient })
+  return render(ui, { wrapper: Providers, ...options })
+}
+
+const createQueryClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        // UPSTREAM: Prevent "Jest did not exit one second after the test run completed" error message.
+        // https://tanstack.com/query/v4/docs/react/guides/testing#set-cachetime-to-infinity-with-jest
+        cacheTime: Infinity,
+      },
+    },
+  })
+
+const createProviders = ({ queryClient }: { queryClient: QueryClient }) => {
+  return function Providers({ children }: PropsWithChildren): JSX.Element {
+    return (
+      <SeamProvider
+        queryClient={queryClient}
+        endpoint={globalThis.JEST_SEAM_ENDPOINT}
+        publishableKey={globalThis.JEST_SEAM_PUBLISHABLE_KEY_1}
+        userIdentifierKey='some_user'
+        disableCssInjection
+        disableFontInjection
+      >
+        {children}
+      </SeamProvider>
+    )
+  }
+}
 
 // eslint-disable-next-line import/export
 export * from '@testing-library/react'


### PR DESCRIPTION
- test: Create QueryClient for each test
- fix: Disallow using apiKey with client

Tests were passing but not really testing what we wanted before:

- Locally: I have SEAM_API key set in my environment. This is the only env var used by the Seam SDK. This was causing the client to fail to initialize as API key and publishable key are incompatible.
- On CI: Tests might have worked, but the test only tested for the loading state, which always happens, so the test passed as soon as it saw the loading state.
- Now: The `apiKey` is passed in explicitly as `undefined`. Current logic in the SDK will respect that as it only sets properties that are not explicitly passed in.

This means testing with https://testing-library.com/ is now fully working.  Further discussion on what to use tests for can be had here: https://github.com/seamapi/react/discussions/38