### PR TITLE
build: Keep README version up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ export function App() {
   <seam-device-table publishable-key="your_publishable_key"></seam-device-table>
   <script
     type="module"
-    src="https://react.seam.co/v/1.16.0/dist/elements.js"
+    src="https://react.seam.co/v/1.30.2/dist/elements.js"
   ></script>
 </body>
 ```

--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "prelint": "prettier --check --ignore-path .gitignore .",
     "postlint": "stylelint '**/*.scss'",
     "prepack": "tsx ./prepack.ts",
+    "version": "tsx ./version.ts",
+    "preversion": "tsx ./preversion.ts",
     "postversion": "git push --follow-tags",
     "storybook": "storybook dev --port 6006",
     "storybook:docs": "storybook dev --docs --port 6007",

--- a/preversion.ts
+++ b/preversion.ts
@@ -1,0 +1,38 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import { $ } from 'execa'
+
+import { readPackageJson } from './vite.config.js'
+
+export const files = ['./README.md']
+
+export const versionPlaceholder = '_________VERSION_________'
+
+const main = async (): Promise<void> => {
+  await Promise.all(
+    files.map(async (file) => {
+      const version = await injectVersionPlaceholder(
+        fileURLToPath(new URL(file, import.meta.url))
+      )
+      // eslint-disable-next-line no-console
+      console.log(`✓ Version ${version} injected into ${file}`)
+      await $`git add ${file}`
+    })
+  )
+}
+
+const injectVersionPlaceholder = async (path: string): Promise<string> => {
+  const { version } = await readPackageJson()
+
+  if (version == null) {
+    throw new Error('Missing version in package.json')
+  }
+
+  const buff = await readFile(path)
+  const data = buff.toString().replaceAll(version, versionPlaceholder)
+  await writeFile(path, data)
+  return version
+}
+
+await main()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,8 @@
     "api/**/*",
     ".storybook/**/*",
     "prepack.ts",
+    "preversion.ts",
+    "version.ts",
     "vite.config.ts"
   ]
 }

--- a/version.ts
+++ b/version.ts
@@ -1,0 +1,33 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
+import { files, versionPlaceholder } from './preversion.js'
+import { readPackageJson } from './vite.config.js'
+
+const main = async (): Promise<void> => {
+  await Promise.all(
+    files.map(async (file) => {
+      const version = await injectVersion(
+        fileURLToPath(new URL(file, import.meta.url))
+      )
+      // eslint-disable-next-line no-console
+      console.log(`✓ Version ${version} injected into ${file}`)
+    })
+  )
+}
+
+const injectVersion = async (path: string): Promise<string> => {
+  const { version } = await readPackageJson()
+
+  if (version == null) {
+    throw new Error('Missing version in package.json')
+  }
+
+  const buff = await readFile(path)
+  const data = buff.toString().replaceAll(versionPlaceholder, version)
+  await writeFile(path, data)
+
+  return version
+}
+
+await main()


### PR DESCRIPTION
We could move the scripts to a sub directory, but I don't mind them at the top level right now. I reserve the right change my mind about that 🙃

This unlocks the ability to have more examples that stay up to date / examples outside the README. It's not clear how to keep the external docs updated with the latest version, but that's out of scope of this repo anyway.