### PR TITLE
feat: Add `heading` prop, deprecate `title`

### DIFF
--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.element.ts
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.element.ts
@@ -13,6 +13,7 @@ export const props: ElementProps<AccessCodeTableProps> = {
   onAccessCodeClick: 'function',
   preventDefaultOnAccessCodeClick: 'boolean',
   onBack: 'function',
+  heading: 'string',
   className: 'string',
 }
 

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -51,6 +51,10 @@ export interface AccessCodeTableProps {
   onAccessCodeClick?: (accessCodeId: string) => void
   preventDefaultOnAccessCodeClick?: boolean
   onBack?: () => void
+  heading?: string | null
+  /**
+   * @deprecated Use `heading` instead
+   */
   title?: string | null
   className?: string
 }
@@ -79,6 +83,7 @@ export function AccessCodeTable({
   onBack,
   accessCodeFilter = defaultAccessCodeFilter,
   accessCodeComparator = compareByCreatedAtDesc,
+  heading = t.accessCodes,
   title = t.accessCodes,
   className,
 }: AccessCodeTableProps): JSX.Element {
@@ -144,7 +149,7 @@ export function AccessCodeTable({
         <div className='seam-left'>
           {title != null ? (
             <TableTitle>
-              {title ?? t.accessCodes}{' '}
+              {heading ?? title ?? t.accessCodes}{' '}
               <Caption>({filteredAccessCodes.length})</Caption>
             </TableTitle>
           ) : (

--- a/src/lib/seam/components/DeviceTable/DeviceTable.element.ts
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.element.ts
@@ -14,6 +14,7 @@ export const props: ElementProps<DeviceTableProps> = {
   onDeviceClick: 'function',
   preventDefaultOnDeviceClick: 'boolean',
   onBack: 'function',
+  heading: 'string',
   className: 'string',
 }
 

--- a/src/lib/seam/components/DeviceTable/DeviceTable.tsx
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.tsx
@@ -34,6 +34,10 @@ export interface DeviceTableProps {
   onDeviceClick?: (deviceId: string) => void
   preventDefaultOnDeviceClick?: boolean
   onBack?: () => void
+  heading?: string | null
+  /**
+   * @deprecated Use `heading` instead
+   */
   title?: string | null
   className?: string
 }
@@ -57,6 +61,7 @@ export function DeviceTable({
   onBack,
   deviceFilter = defaultDeviceFilter,
   deviceComparator = compareByCreatedAtDesc,
+  heading = t.devices,
   title = t.devices,
   className,
 }: DeviceTableProps = {}): JSX.Element {
@@ -113,7 +118,8 @@ export function DeviceTable({
       <TableHeader>
         {title != null ? (
           <TableTitle>
-            {title ?? t.devices} <Caption>({filteredDevices.length})</Caption>
+            {heading ?? title ?? t.devices}{' '}
+            <Caption>({filteredDevices.length})</Caption>
           </TableTitle>
         ) : (
           <div className='seam-fragment' />


### PR DESCRIPTION
Deprecates the `title` prop for `DeviceTable`, `AccessCodeTable`—adds `heading` as a replacement.