### PR TITLE
feat(AccessCode): add ability to delete

### DIFF
--- a/src/lib/seam/access-codes/use-delete-access-code.ts
+++ b/src/lib/seam/access-codes/use-delete-access-code.ts
@@ -33,7 +33,6 @@ export function useDeleteAccessCode(): UseMutationResult<
   >({
     mutationFn: async (mutationParams: UseDeleteAccessCodeMutationParams) => {
       if (client === null) throw new NullSeamClientError()
-
       return await client.accessCodes.delete(mutationParams)
     },
     onSuccess: (_data, variables) => {

--- a/src/lib/seam/access-codes/use-delete-access-code.ts
+++ b/src/lib/seam/access-codes/use-delete-access-code.ts
@@ -1,0 +1,48 @@
+import {
+  useMutation,
+  type UseMutationResult,
+  useQueryClient,
+} from '@tanstack/react-query'
+import type {
+  AccessCodeDeleteRequest,
+  ActionAttempt,
+  ActionType,
+  SeamError,
+} from 'seamapi'
+
+import { NullSeamClientError, useSeamClient } from 'lib/seam/use-seam-client.js'
+
+export type UseDeleteAccessCodeParams = never
+export interface UseDeleteAccessCodeData {
+  actionAttempt: ActionAttempt<ActionType>
+}
+export type UseDeleteAccessCodeMutationParams = AccessCodeDeleteRequest
+
+export function useDeleteAccessCode(): UseMutationResult<
+  UseDeleteAccessCodeData,
+  SeamError,
+  UseDeleteAccessCodeMutationParams
+> {
+  const { client } = useSeamClient()
+  const queryClient = useQueryClient()
+
+  return useMutation<
+    UseDeleteAccessCodeData,
+    SeamError,
+    AccessCodeDeleteRequest
+  >({
+    mutationFn: async (mutationParams: UseDeleteAccessCodeMutationParams) => {
+      if (client === null) throw new NullSeamClientError()
+
+      return await client.accessCodes.delete(mutationParams)
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries([
+        'access_codes',
+        'get',
+        { access_code_id: variables.access_code_id },
+      ])
+      void queryClient.invalidateQueries(['access_codes', 'list'])
+    },
+  })
+}

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
@@ -7,6 +7,7 @@ export const name = 'seam-access-code-details'
 export const props: ElementProps<AccessCodeDetailsProps> = {
   accessCodeId: 'string',
   disableLockUnlock: 'boolean',
+  disableDeleteAccessCode: 'boolean',
   onBack: 'object',
   onEdit: 'object',
   className: 'string',

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -34,7 +34,7 @@ export function AccessCodeDetails({
   onBack,
   onEdit,
   className,
-  disableDeleteAccessCode = false
+  disableDeleteAccessCode = false,
 }: AccessCodeDetailsProps): JSX.Element | null {
   const { accessCode } = useAccessCode(accessCodeId)
   const [selectedDeviceId, selectDevice] = useState<string | null>(null)

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -37,7 +37,7 @@ export function AccessCodeDetails({
 }: AccessCodeDetailsProps): JSX.Element | null {
   const { accessCode } = useAccessCode(accessCodeId)
   const [selectedDeviceId, selectDevice] = useState<string | null>(null)
-  const {mutate: deleteCode, isLoading: isDeleting} = useDeleteAccessCode()
+  const { mutate: deleteCode, isLoading: isDeleting } = useDeleteAccessCode()
 
   if (accessCode == null) {
     return null
@@ -95,23 +95,24 @@ export function AccessCodeDetails({
           onSelectDevice={selectDevice}
         />
       </div>
-      {(!disableEditAccessCode || !disableDeleteAccessCode )&& (
+      {(!disableEditAccessCode || !disableDeleteAccessCode) && (
         <div className='seam-actions'>
-          {
-            !disableEditAccessCode && (
-              <Button size='small' onClick={onEdit}
-               disabled={isDeleting}>
-                {t.editCode}
-              </Button>
-            )
-          }
-          {
-            !disableDeleteAccessCode && (
-              <Button size='small' onClick={() => { deleteCode({access_code_id: accessCode.access_code_id}); }} disabled={isDeleting}>
+          {!disableEditAccessCode && (
+            <Button size='small' onClick={onEdit} disabled={isDeleting}>
+              {t.editCode}
+            </Button>
+          )}
+          {!disableDeleteAccessCode && (
+            <Button
+              size='small'
+              onClick={() => {
+                deleteCode({ access_code_id: accessCode.access_code_id })
+              }}
+              disabled={isDeleting}
+            >
               {t.deleteCode}
             </Button>
-            )
-          }
+          )}
         </div>
       )}
       <div className='seam-details'>

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -9,6 +9,7 @@ import type {
 } from 'seamapi'
 
 import { useAccessCode } from 'lib/seam/access-codes/use-access-code.js'
+import { useDeleteAccessCode } from 'lib/seam/access-codes/use-delete-access-code.js'
 import { AccessCodeDevice } from 'lib/seam/components/AccessCodeDetails/AccessCodeDevice.js'
 import { DeviceDetails } from 'lib/seam/components/DeviceDetails/DeviceDetails.js'
 import { Alerts } from 'lib/ui/Alert/Alerts.js'
@@ -17,6 +18,7 @@ import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
 import { useIsDateInPast } from 'lib/ui/use-is-date-in-past.js'
 
 const disableEditAccessCode = true
+const disableDeleteAccessCode = true
 
 export interface AccessCodeDetailsProps {
   accessCodeId: string
@@ -35,6 +37,7 @@ export function AccessCodeDetails({
 }: AccessCodeDetailsProps): JSX.Element | null {
   const { accessCode } = useAccessCode(accessCodeId)
   const [selectedDeviceId, selectDevice] = useState<string | null>(null)
+  const {mutate: deleteCode, isLoading: isDeleting} = useDeleteAccessCode()
 
   if (accessCode == null) {
     return null
@@ -92,11 +95,23 @@ export function AccessCodeDetails({
           onSelectDevice={selectDevice}
         />
       </div>
-      {!disableEditAccessCode && (
+      {(!disableEditAccessCode || !disableDeleteAccessCode )&& (
         <div className='seam-actions'>
-          <Button size='small' onClick={onEdit}>
-            {t.editCode}
-          </Button>
+          {
+            !disableEditAccessCode && (
+              <Button size='small' onClick={onEdit}
+               disabled={isDeleting}>
+                {t.editCode}
+              </Button>
+            )
+          }
+          {
+            !disableDeleteAccessCode && (
+              <Button size='small' onClick={() => { deleteCode({access_code_id: accessCode.access_code_id}); }} disabled={isDeleting}>
+              {t.deleteCode}
+            </Button>
+            )
+          }
         </div>
       )}
       <div className='seam-details'>
@@ -224,4 +239,5 @@ const t = {
   start: 'Start',
   end: 'End',
   editCode: 'Edit code',
+  deleteCode: 'Delete code',
 }

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -18,7 +18,6 @@ import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
 import { useIsDateInPast } from 'lib/ui/use-is-date-in-past.js'
 
 const disableEditAccessCode = true
-const disableDeleteAccessCode = true
 
 export interface AccessCodeDetailsProps {
   accessCodeId: string
@@ -26,6 +25,7 @@ export interface AccessCodeDetailsProps {
   onBack?: () => void
   onEdit: () => void
   className?: string
+  disableDeleteAccessCode?: boolean
 }
 
 export function AccessCodeDetails({
@@ -34,6 +34,7 @@ export function AccessCodeDetails({
   onBack,
   onEdit,
   className,
+  disableDeleteAccessCode = false
 }: AccessCodeDetailsProps): JSX.Element | null {
   const { accessCode } = useAccessCode(accessCodeId)
   const [selectedDeviceId, selectDevice] = useState<string | null>(null)

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -49,7 +49,7 @@ function Content({
             onClick={toggleDeleteConfirmation}
             disabled={deleteAccessCode.isLoading}
           >
-          {t.cancelDelete}
+            {t.cancelDelete}
           </Button>
           <Button
             variant='solid'
@@ -60,7 +60,7 @@ function Content({
               })
             }}
           >
-          {t.confirmDelete}
+            {t.confirmDelete}
           </Button>
         </div>
       </div>
@@ -114,5 +114,5 @@ const t = {
   deleteCode: 'Delete code',
   deleteCodeConfirmation: 'Delete this code and data?',
   cancelDelete: 'Cancel',
-  confirmDelete: 'Delete'
+  confirmDelete: 'Delete',
 }

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -43,13 +43,13 @@ function Content({
   if (deleteConfirmationVisible) {
     return (
       <div className='seam-delete-confirmation'>
-        <span>Delete this code and data?</span>
+        <span>{t.deleteCodeConfirmation}</span>
         <div className='seam-actions'>
           <Button
             onClick={toggleDeleteConfirmation}
             disabled={deleteAccessCode.isLoading}
           >
-            Cancel
+          {t.cancelDelete}
           </Button>
           <Button
             variant='solid'
@@ -60,7 +60,7 @@ function Content({
               })
             }}
           >
-            Delete
+          {t.confirmDelete}
           </Button>
         </div>
       </div>
@@ -112,4 +112,7 @@ const t = {
   editCode: 'Edit code',
   viewCodeDetails: 'View code details',
   deleteCode: 'Delete code',
+  deleteCodeConfirmation: 'Delete this code and data?',
+  cancelDelete: 'Cancel',
+  confirmDelete: 'Delete'
 }

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -94,7 +94,7 @@ function Content({
               event.stopPropagation() // Prevent hiding menu on outside click
               toggleDeleteConfirmation()
             }}
-            disableCloseOnClick
+            preventDefaultOnClick
             className='seam-text-danger'
           >
             {t.deleteCode}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -1,0 +1,98 @@
+import { CopyIcon } from 'lib/icons/Copy.js'
+import type { UseAccessCodeData } from 'lib/seam/access-codes/use-access-code.js'
+import { useDeleteAccessCode } from 'lib/seam/access-codes/use-delete-access-code.js'
+import { Button } from 'lib/ui/Button.js'
+import { copyToClipboard } from 'lib/ui/clipboard.js'
+import { MenuItem } from 'lib/ui/Menu/MenuItem.js'
+import { MoreActionsMenu } from 'lib/ui/Menu/MoreActionsMenu.js'
+import { useToggle } from 'lib/ui/use-toggle.js'
+
+export interface AccessCodeMenuProps {
+  accessCode: NonNullable<UseAccessCodeData>
+  onEdit: () => void
+  onViewDetails: () => void
+  disableEditAccessCode: boolean
+  disableDeleteAccessCode: boolean
+}
+
+export function AccessCodeMenu(props: AccessCodeMenuProps): JSX.Element {
+  return (
+    <MoreActionsMenu
+      menuProps={{
+        backgroundProps: {
+          className: 'seam-access-code-table-action-menu',
+        },
+      }}
+    >
+      <Content {...props} />
+    </MoreActionsMenu>
+  )
+}
+
+function Content({
+  accessCode,
+  onViewDetails,
+  disableEditAccessCode,
+  disableDeleteAccessCode,
+  onEdit,
+}: AccessCodeMenuProps): JSX.Element {
+
+  const [deleteConfirmationVisible, toggleDeleteConfirmation] = useToggle()
+
+  const deleteAccessCode = useDeleteAccessCode()
+
+  if(deleteConfirmationVisible) {
+    return <div className='seam-delete-confirmation'>
+      <span>
+        Delete this code and data?
+      </span>
+      <div className='seam-actions'>
+        <Button onClick={toggleDeleteConfirmation}
+        disabled={deleteAccessCode.isLoading}>Cancel</Button>
+        <Button variant="solid" disabled={deleteAccessCode.isLoading} onClick={() => { deleteAccessCode.mutate({access_code_id: accessCode.access_code_id}); }}>Delete</Button>
+      </div>
+    </div>
+  }
+
+  return (
+    <>
+      <MenuItem
+        onClick={() => {
+          void copyToClipboard(accessCode.code ?? '')
+        }}
+      >
+        <div className='seam-menu-item-copy'>
+          <span>
+            {t.copyCode} - {accessCode.code}
+          </span>
+          <CopyIcon />
+        </div>
+      </MenuItem>
+      <div className='seam-divider' />
+      <MenuItem onClick={onViewDetails}>{t.viewCodeDetails}</MenuItem>
+      {!disableEditAccessCode && (
+        <MenuItem onClick={onEdit}>{t.editCode}</MenuItem>
+      )}
+      {!disableDeleteAccessCode && (
+        <>
+          <div className='seam-divider' />
+          <MenuItem onClick={event => {
+            event.stopPropagation() // Prevent hiding menu on outside click
+            toggleDeleteConfirmation()
+          }} disableCloseOnClick className='seam-text-danger'>
+            {t.deleteCode}
+          </MenuItem>
+        </>
+      )}
+    </>
+  )
+}
+
+const t = {
+  copyCode: 'Copy code',
+  codeIssue: 'code issue',
+  codeIssues: 'code issues',
+  editCode: 'Edit code',
+  viewCodeDetails: 'View code details',
+  deleteCode: 'Delete code',
+}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -36,22 +36,35 @@ function Content({
   disableDeleteAccessCode,
   onEdit,
 }: AccessCodeMenuProps): JSX.Element {
-
   const [deleteConfirmationVisible, toggleDeleteConfirmation] = useToggle()
 
   const deleteAccessCode = useDeleteAccessCode()
 
-  if(deleteConfirmationVisible) {
-    return <div className='seam-delete-confirmation'>
-      <span>
-        Delete this code and data?
-      </span>
-      <div className='seam-actions'>
-        <Button onClick={toggleDeleteConfirmation}
-        disabled={deleteAccessCode.isLoading}>Cancel</Button>
-        <Button variant="solid" disabled={deleteAccessCode.isLoading} onClick={() => { deleteAccessCode.mutate({access_code_id: accessCode.access_code_id}); }}>Delete</Button>
+  if (deleteConfirmationVisible) {
+    return (
+      <div className='seam-delete-confirmation'>
+        <span>Delete this code and data?</span>
+        <div className='seam-actions'>
+          <Button
+            onClick={toggleDeleteConfirmation}
+            disabled={deleteAccessCode.isLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant='solid'
+            disabled={deleteAccessCode.isLoading}
+            onClick={() => {
+              deleteAccessCode.mutate({
+                access_code_id: accessCode.access_code_id,
+              })
+            }}
+          >
+            Delete
+          </Button>
+        </div>
       </div>
-    </div>
+    )
   }
 
   return (
@@ -76,10 +89,14 @@ function Content({
       {!disableDeleteAccessCode && (
         <>
           <div className='seam-divider' />
-          <MenuItem onClick={event => {
-            event.stopPropagation() // Prevent hiding menu on outside click
-            toggleDeleteConfirmation()
-          }} disableCloseOnClick className='seam-text-danger'>
+          <MenuItem
+            onClick={(event) => {
+              event.stopPropagation() // Prevent hiding menu on outside click
+              toggleDeleteConfirmation()
+            }}
+            disableCloseOnClick
+            className='seam-text-danger'
+          >
             {t.deleteCode}
           </MenuItem>
         </>

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
@@ -1,0 +1,73 @@
+import { AccessCodeKeyIcon } from 'lib/icons/AccessCodeKey.js'
+import { ExclamationCircleOutlineIcon } from 'lib/icons/ExclamationCircleOutline.js'
+import { TriangleWarningOutlineIcon } from 'lib/icons/TriangleWarningOutline.js'
+import type { UseAccessCodesData } from 'lib/seam/access-codes/use-access-codes.js'
+import { AccessCodeMenu } from 'lib/seam/components/AccessCodeTable/AccessCodeMenu.js'
+import { CodeDetails } from 'lib/seam/components/AccessCodeTable/CodeDetails.js'
+import { TableCell } from 'lib/ui/Table/TableCell.js'
+import { TableRow } from 'lib/ui/Table/TableRow.js'
+import { Title } from 'lib/ui/typography/Title.js'
+
+export interface AccessCodeRowProps {
+  accessCode: UseAccessCodesData[number]
+  onClick: () => void
+  onEdit: () => void
+  disableEditAccessCode: boolean
+  disableDeleteAccessCode: boolean
+}
+
+export function AccessCodeRow({
+  onClick,
+  accessCode,
+  onEdit,
+  disableEditAccessCode,
+  disableDeleteAccessCode,
+}: AccessCodeRowProps): JSX.Element {
+  const errorCount = accessCode.errors.length
+  const warningCount = accessCode.warnings.length
+  const isPlural = errorCount === 0 || errorCount > 1
+  const errorIconTitle = isPlural
+    ? `${errorCount} ${t.codeIssues}`
+    : `${errorCount} ${t.codeIssue}`
+  const warningIconTitle = isPlural
+    ? `${warningCount} ${t.codeIssues}`
+    : `${warningCount} ${t.codeIssue}`
+
+  return (
+    <TableRow onClick={onClick}>
+      <TableCell className='seam-icon-cell'>
+        <div>
+          <AccessCodeKeyIcon />
+        </div>
+      </TableCell>
+      <TableCell className='seam-name-cell'>
+        <Title className='seam-truncated-text'>{accessCode.name}</Title>
+        <CodeDetails accessCode={accessCode} />
+      </TableCell>
+      <TableCell className='seam-action-cell'>
+        {errorCount > 0 && (
+          <div className='seam-code-issue-icon-wrap' title={errorIconTitle}>
+            <ExclamationCircleOutlineIcon />
+          </div>
+        )}
+        {errorCount === 0 && warningCount > 0 && (
+          <div className='seam-code-issue-icon-wrap' title={warningIconTitle}>
+            <TriangleWarningOutlineIcon />
+          </div>
+        )}
+        <AccessCodeMenu
+          accessCode={accessCode}
+          onEdit={onEdit}
+          onViewDetails={onClick}
+          disableDeleteAccessCode={disableDeleteAccessCode}
+          disableEditAccessCode={disableEditAccessCode}
+        />
+      </TableCell>
+    </TableRow>
+  )
+}
+
+const t = {
+  codeIssue: 'code issue',
+  codeIssues: 'code issues',
+}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.element.ts
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.element.ts
@@ -7,6 +7,7 @@ export const name = 'seam-access-code-table'
 export const props: ElementProps<Omit<AccessCodeTableProps, 'title'>> = {
   deviceId: 'string',
   disableLockUnlock: 'boolean',
+  disableDeleteAccessCode: 'boolean',
   disableSearch: 'boolean',
   accessCodeFilter: 'object',
   accessCodeComparator: 'object',

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -36,7 +36,7 @@ import { Title } from 'lib/ui/typography/Title.js'
 import { useToggle } from 'lib/ui/use-toggle.js'
 
 const disableCreateAccessCode = true
-const disableEditAccessCode = false
+const disableEditAccessCode = true
 
 export interface AccessCodeTableProps {
   deviceId: string

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -2,11 +2,7 @@ import classNames from 'classnames'
 import { useCallback, useMemo, useState } from 'react'
 
 import { compareByCreatedAtDesc } from 'lib/dates.js'
-import { AccessCodeKeyIcon } from 'lib/icons/AccessCodeKey.js'
 import { AddIcon } from 'lib/icons/Add.js'
-import { CopyIcon } from 'lib/icons/Copy.js'
-import { ExclamationCircleOutlineIcon } from 'lib/icons/ExclamationCircleOutline.js'
-import { TriangleWarningOutlineIcon } from 'lib/icons/TriangleWarningOutline.js'
 import {
   useAccessCodes,
   type UseAccessCodesData,
@@ -16,27 +12,22 @@ import {
   type AccessCodeFilter,
   AccessCodeHealthBar,
 } from 'lib/seam/components/AccessCodeTable/AccessCodeHealthBar.js'
-import { CodeDetails } from 'lib/seam/components/AccessCodeTable/CodeDetails.js'
+import { AccessCodeRow } from 'lib/seam/components/AccessCodeTable/AccessCodeRow.js'
 import { CreateAccessCodeForm } from 'lib/seam/components/CreateAccessCodeForm/CreateAccessCodeForm.js'
 import { EditAccessCodeForm } from 'lib/seam/components/EditAccessCodeForm/EditAccessCodeForm.js'
-import { copyToClipboard } from 'lib/ui/clipboard.js'
 import { IconButton } from 'lib/ui/IconButton.js'
 import { ContentHeader } from 'lib/ui/layout/ContentHeader.js'
-import { MenuItem } from 'lib/ui/Menu/MenuItem.js'
-import { MoreActionsMenu } from 'lib/ui/Menu/MoreActionsMenu.js'
 import { EmptyPlaceholder } from 'lib/ui/Table/EmptyPlaceholder.js'
 import { TableBody } from 'lib/ui/Table/TableBody.js'
-import { TableCell } from 'lib/ui/Table/TableCell.js'
 import { TableHeader } from 'lib/ui/Table/TableHeader.js'
-import { TableRow } from 'lib/ui/Table/TableRow.js'
 import { TableTitle } from 'lib/ui/Table/TableTitle.js'
 import { SearchTextField } from 'lib/ui/TextField/SearchTextField.js'
 import { Caption } from 'lib/ui/typography/Caption.js'
-import { Title } from 'lib/ui/typography/Title.js'
 import { useToggle } from 'lib/ui/use-toggle.js'
 
 const disableCreateAccessCode = true
-const disableEditAccessCode = true
+const disableEditAccessCode = false
+const disableDeleteAccessCode = false
 
 export interface AccessCodeTableProps {
   deviceId: string
@@ -258,6 +249,7 @@ function Content(props: {
             onAccessCodeClick(accessCode.access_code_id)
           }}
           disableEditAccessCode={disableEditAccessCode}
+          disableDeleteAccessCode={disableDeleteAccessCode}
           onEdit={() => {
             onAccessCodeEdit(accessCode.access_code_id)
           }}
@@ -267,82 +259,7 @@ function Content(props: {
   )
 }
 
-function AccessCodeRow(props: {
-  accessCode: UseAccessCodesData[number]
-  onClick: () => void
-  onEdit: () => void
-  disableEditAccessCode: boolean
-}): JSX.Element {
-  const { onClick, accessCode, onEdit, disableEditAccessCode } = props
-
-  const errorCount = accessCode.errors.length
-  const warningCount = accessCode.warnings.length
-  const isPlural = errorCount === 0 || errorCount > 1
-  const errorIconTitle = isPlural
-    ? `${errorCount} ${t.codeIssues}`
-    : `${errorCount} ${t.codeIssue}`
-  const warningIconTitle = isPlural
-    ? `${warningCount} ${t.codeIssues}`
-    : `${warningCount} ${t.codeIssue}`
-
-  return (
-    <TableRow onClick={onClick}>
-      <TableCell className='seam-icon-cell'>
-        <div>
-          <AccessCodeKeyIcon />
-        </div>
-      </TableCell>
-      <TableCell className='seam-name-cell'>
-        <Title className='seam-truncated-text'>{accessCode.name}</Title>
-        <CodeDetails accessCode={accessCode} />
-      </TableCell>
-      <TableCell className='seam-action-cell'>
-        {errorCount > 0 && (
-          <div className='seam-code-issue-icon-wrap' title={errorIconTitle}>
-            <ExclamationCircleOutlineIcon />
-          </div>
-        )}
-        {errorCount === 0 && warningCount > 0 && (
-          <div className='seam-code-issue-icon-wrap' title={warningIconTitle}>
-            <TriangleWarningOutlineIcon />
-          </div>
-        )}
-        <MoreActionsMenu
-          menuProps={{
-            backgroundProps: {
-              className: 'seam-access-code-table-action-menu',
-            },
-          }}
-        >
-          <MenuItem
-            onClick={() => {
-              void copyToClipboard(accessCode.code ?? '')
-            }}
-          >
-            <div className='seam-menu-item-copy'>
-              <span>
-                {t.copyCode} - {accessCode.code}
-              </span>
-              <CopyIcon />
-            </div>
-          </MenuItem>
-          {!disableEditAccessCode && (
-            <>
-              <div className='seam-divider' />
-              <MenuItem onClick={onEdit}>{t.editCode}</MenuItem>
-            </>
-          )}
-        </MoreActionsMenu>
-      </TableCell>
-    </TableRow>
-  )
-}
-
 const t = {
   accessCodes: 'Access Codes',
-  copyCode: 'Copy code',
   noAccessCodesMessage: 'Sorry, no access codes were found',
-  codeIssue: 'code issue',
-  codeIssues: 'code issues',
-  editCode: 'Edit code',
 }

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -27,7 +27,6 @@ import { useToggle } from 'lib/ui/use-toggle.js'
 
 const disableCreateAccessCode = true
 const disableEditAccessCode = true
-const disableDeleteAccessCode = true
 
 export interface AccessCodeTableProps {
   deviceId: string
@@ -50,6 +49,7 @@ export interface AccessCodeTableProps {
    */
   title?: string | null
   className?: string
+  disableDeleteAccessCode?: boolean
 }
 
 type AccessCode = UseAccessCodesData[number]
@@ -79,6 +79,7 @@ export function AccessCodeTable({
   heading = t.accessCodes,
   title = t.accessCodes,
   className,
+  disableDeleteAccessCode=false
 }: AccessCodeTableProps): JSX.Element {
   const { accessCodes } = useAccessCodes({
     device_id: deviceId,
@@ -146,6 +147,7 @@ export function AccessCodeTable({
         onEdit={() => {
           setSelectedEditAccessCodeId(selectedViewAccessCodeId)
         }}
+        disableDeleteAccessCode={disableDeleteAccessCode}
       />
     )
   }
@@ -196,6 +198,7 @@ export function AccessCodeTable({
           onAccessCodeClick={handleAccessCodeClick}
           onAccessCodeEdit={handleAccessCodeEdit}
           disableEditAccessCode={disableEditAccessCode}
+          disableDeleteAccessCode={disableDeleteAccessCode}
         />
       </TableBody>
     </div>
@@ -207,12 +210,14 @@ function Content(props: {
   onAccessCodeClick: (accessCodeId: string) => void
   onAccessCodeEdit: (accessCodeId: string) => void
   disableEditAccessCode: boolean
+  disableDeleteAccessCode: boolean
 }): JSX.Element {
   const {
     accessCodes,
     onAccessCodeClick,
     onAccessCodeEdit,
     disableEditAccessCode,
+    disableDeleteAccessCode,
   } = props
   const [filter, setFilter] = useState<AccessCodeFilter | null>(null)
 

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -26,8 +26,8 @@ import { Caption } from 'lib/ui/typography/Caption.js'
 import { useToggle } from 'lib/ui/use-toggle.js'
 
 const disableCreateAccessCode = true
-const disableEditAccessCode = false
-const disableDeleteAccessCode = false
+const disableEditAccessCode = true
+const disableDeleteAccessCode = true
 
 export interface AccessCodeTableProps {
   deviceId: string

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -79,7 +79,7 @@ export function AccessCodeTable({
   heading = t.accessCodes,
   title = t.accessCodes,
   className,
-  disableDeleteAccessCode=false
+  disableDeleteAccessCode = false,
 }: AccessCodeTableProps): JSX.Element {
   const { accessCodes } = useAccessCodes({
     device_id: deviceId,

--- a/src/lib/ui/Menu/MenuItem.tsx
+++ b/src/lib/ui/Menu/MenuItem.tsx
@@ -6,14 +6,14 @@ import { useMenu } from 'lib/ui/Menu/Menu.js'
 interface MenuItemProps extends PropsWithChildren {
   onClick: (event: React.MouseEvent) => void
   className?: string
-  disableCloseOnClick?: boolean
+  preventDefaultOnClick?: boolean
 }
 
 export function MenuItem({
   onClick,
   children,
   className,
-  disableCloseOnClick = false,
+  preventDefaultOnClick = false,
 }: MenuItemProps): JSX.Element {
   const { close: closeMenu } = useMenu()
 
@@ -23,7 +23,7 @@ export function MenuItem({
       onClick={(event: React.MouseEvent) => {
         onClick(event)
 
-        if (!disableCloseOnClick) {
+        if (!preventDefaultOnClick) {
           closeMenu()
         }
       }}

--- a/src/lib/ui/Menu/MenuItem.tsx
+++ b/src/lib/ui/Menu/MenuItem.tsx
@@ -13,7 +13,7 @@ export function MenuItem({
   onClick,
   children,
   className,
-  disableCloseOnClick = false
+  disableCloseOnClick = false,
 }: MenuItemProps): JSX.Element {
   const { close: closeMenu } = useMenu()
 
@@ -23,8 +23,7 @@ export function MenuItem({
       onClick={(event: React.MouseEvent) => {
         onClick(event)
 
-
-        if(!disableCloseOnClick)  {
+        if (!disableCloseOnClick) {
           closeMenu()
         }
       }}

--- a/src/lib/ui/Menu/MenuItem.tsx
+++ b/src/lib/ui/Menu/MenuItem.tsx
@@ -1,20 +1,32 @@
+import classNames from 'classnames'
 import type { PropsWithChildren } from 'react'
 
 import { useMenu } from 'lib/ui/Menu/Menu.js'
 
 interface MenuItemProps extends PropsWithChildren {
-  onClick: () => void
+  onClick: (event: React.MouseEvent) => void
+  className?: string
+  disableCloseOnClick?: boolean
 }
 
-export function MenuItem({ onClick, children }: MenuItemProps): JSX.Element {
+export function MenuItem({
+  onClick,
+  children,
+  className,
+  disableCloseOnClick = false
+}: MenuItemProps): JSX.Element {
   const { close: closeMenu } = useMenu()
 
   return (
     <div
-      className='seam-menu-item'
-      onClick={() => {
-        onClick()
-        closeMenu()
+      className={classNames('seam-menu-item', className)}
+      onClick={(event: React.MouseEvent) => {
+        onClick(event)
+
+
+        if(!disableCloseOnClick)  {
+          closeMenu()
+        }
       }}
     >
       {children}

--- a/src/styles/_access-code-details.scss
+++ b/src/styles/_access-code-details.scss
@@ -82,6 +82,8 @@
     .seam-actions {
       margin-bottom: 16px;
       padding: 0 24px;
+      display: flex;
+      gap: 8px;
     }
 
     .seam-details {

--- a/src/styles/_access-code-table.scss
+++ b/src/styles/_access-code-table.scss
@@ -26,7 +26,7 @@
         align-items: center;
         justify-content: center;
 
-        >div {
+        > div {
           width: 40px;
           height: 40px;
           display: flex;

--- a/src/styles/_access-code-table.scss
+++ b/src/styles/_access-code-table.scss
@@ -26,7 +26,7 @@
         align-items: center;
         justify-content: center;
 
-        > div {
+        >div {
           width: 40px;
           height: 40px;
           display: flex;
@@ -82,6 +82,18 @@
   }
 
   .seam-access-code-table-action-menu {
+    .seam-delete-confirmation {
+      padding: 8px 16px;
+      text-align: center;
+
+      .seam-actions {
+        margin-top: 16px;
+        display: flex;
+        gap: 8px;
+        justify-content: center;
+      }
+    }
+
     .seam-menu-item-copy {
       display: flex;
       align-items: center;


### PR DESCRIPTION
Closes #327 

### Dependencies

- https://github.com/seamapi/fake-seam-connect/pull/48

### Notable things

- Added a `disableDeleteAccessCode` prop, similar to `disableEditAccessCode`.
- Added **View code details menu item**

### Screenshots

<img width="495" alt="CleanShot 2023-08-01 at 01 31 12@2x" src="https://github.com/seamapi/react/assets/11449462/99a6d4cd-1a33-4583-81da-b1f122be5983">


https://github.com/seamapi/react/assets/11449462/7dc34ac8-99ab-4b94-b696-ef9578d7eace

