### PR TITLE
fix: Use div over td

### DIFF
--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceContent.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceContent.tsx
@@ -132,13 +132,13 @@ function EmptyResult({
   )
 
   return (
-    <tr className='seam-supported-device-table-content-message-row'>
-      <td colSpan={6}>
+    <div className='seam-supported-device-table-content-message-row'>
+      <div>
         <div className='seam-supported-device-table-content-message'>
           {filterValue.length === 0 ? <p>{t.noneFound}</p> : noMatchingRows}
         </div>
-      </td>
-    </tr>
+      </div>
+    </div>
   )
 }
 


### PR DESCRIPTION
This was generating a warning in the console. I think it was left over from an older table based design?
<img width="607" alt="image" src="https://github.com/seamapi/react/assets/721372/7bef333c-6316-43a5-afc0-ef5aa60bb696">
