### PR TITLE
Serve assets from R2

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,10 +17,3 @@ resource "cloudflare_r2_bucket" "main" {
   name       = join("-", [local.org, local.repo, local.id])
   location   = "WNAM"
 }
-
-resource "cloudflare_record" "main" {
-  zone_id = local.zone_id
-  name    = var.subdomain
-  value   = cloudflare_r2_bucket.main.name
-  type    = "R2"
-}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,7 +9,8 @@ data "cloudflare_zone" "main" {
 }
 
 locals {
-  zone_id = data.cloudflare_zone.main.id
+  zone_id       = data.cloudflare_zone.main.id
+  bucket_domain = "${var.subdomain}.${var.zone_name}"
 }
 
 resource "cloudflare_r2_bucket" "main" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,5 +22,5 @@ resource "cloudflare_record" "main" {
   zone_id = local.zone_id
   name    = var.subdomain
   value   = cloudflare_r2_bucket.main.name
-  type    = "CNAME"
+  type    = "R2"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,10 +1,20 @@
 // UPSTREAM: Cannot set R2 custom domain via Terraform.
 // https://github.com/cloudflare/terraform-provider-cloudflare/issues/2537
 output "r2_custom_domain" {
-  description = "Enable the custom domain for the R2 bucket manually/"
+  description = "Enable the custom domain for the R2 bucket manually."
   value = {
     zone_id = local.zone_id
-    domain  = "${var.subdomain}.${var.zone_name}"
+    domain  = local.bucket_domain
     bucket  = cloudflare_r2_bucket.main.name
   }
+}
+
+output "vercel_rewrites" {
+  description = "Set these rewrites in vercel.json."
+  value = [
+    {
+      source      = "/v/:version/:asset*",
+      destination = "https://${local.bucket_domain}/v/:version/:asset"
+    },
+  ]
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,10 @@
+// UPSTREAM: Cannot set R2 custom domain via Terraform.
+// https://github.com/cloudflare/terraform-provider-cloudflare/issues/2537
+output "r2_custom_domain" {
+  description = "Enable the custom domain for the R2 bucket manually/"
+  value = {
+    zone_id = local.zone_id
+    domain  = "${var.subdomain}.${var.zone_name}"
+    bucket  = cloudflare_r2_bucket.main.name
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
   "rewrites": [
     {
       "source": "/v/:version/:asset*",
-      "destination": "https://www.unpkg.com/@seamapi/react@:version/:asset"
+      "destination": "https://react.seam.net/v/:version/:asset"
     },
     {
       "source": "/api/:apipath*",


### PR DESCRIPTION
- Use R2 DNS type
- Use output for custom R2 domain
- feat: Serve assets from R2

See https://react.seam.net/v/1.45.2/dist/elements.js and via preview env https://react-git-serve-assets-from-bucket-seamapi.vercel.app/v/1.45.2/dist/elements.js