### PR TITLE
fix: Set CORS headers for assets

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -72,6 +72,10 @@
         {
           "key": "Access-Control-Allow-Headers",
           "value": "*"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -55,6 +55,27 @@
       ]
     },
     {
+      "source": "/v/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET"
+        },
+        {
+          "key": "Access-Control-Allow-Credentials",
+          "value": "false"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "*"
+        }
+      ]
+    },
+    {
       "source": "/examples/(.*)",
       "headers": [
         {


### PR DESCRIPTION
Needed to allow js files to be loaded via script tag. Verified working via 
<img width="740" alt="image" src="https://github.com/seamapi/react/assets/721372/83a0e68b-9dc4-4c14-9f09-f2fcf9cb61ad">
