### PR TITLE
Fix `ClimateSettingStatus` temperature unit

### DIFF
--- a/src/lib/ui/thermostat/ClimateSettingStatus.tsx
+++ b/src/lib/ui/thermostat/ClimateSettingStatus.tsx
@@ -23,8 +23,16 @@ export function ClimateSettingStatus({
       )}
       <Content
         mode={climateSetting.hvac_mode_setting}
-        coolingSetPoint={climateSetting.cooling_set_point_fahrenheit}
-        heatingSetPoint={climateSetting.heating_set_point_fahrenheit}
+        coolingSetPoint={
+          temperatureUnit === 'fahrenheit'
+            ? climateSetting.cooling_set_point_fahrenheit
+            : climateSetting.cooling_set_point_celsius
+        }
+        heatingSetPoint={
+          temperatureUnit === 'fahrenheit'
+            ? climateSetting.heating_set_point_fahrenheit
+            : climateSetting.heating_set_point_celsius
+        }
         temperatureUnit={temperatureUnit}
       />
       {iconPlacement === 'right' && (


### PR DESCRIPTION
Toggle between fahrenheit and celsius reference depending on `temperatureUnit`