### PR TITLE
refactor: Prefer globalThis. over globalThis?.

### DIFF
--- a/src/lib/element.tsx
+++ b/src/lib/element.tsx
@@ -53,7 +53,7 @@ export const defineCustomElement = ({
       ...providerProps,
     },
   })
-  globalThis?.customElements?.define(name, element)
+  globalThis.customElements?.define(name, element)
 }
 
 function withProvider<P extends JSX.IntrinsicAttributes>(
@@ -82,7 +82,7 @@ function withProvider<P extends JSX.IntrinsicAttributes>(
         disableFontInjection={
           disableFontInjection ?? globalThis.disableSeamFontInjection
         }
-        unminifiyCss={unminifiyCss ?? globalThis?.unminifiySeamCss}
+        unminifiyCss={unminifiyCss ?? globalThis.unminifiySeamCss}
       >
         <Component {...(props as P)} />
       </SeamProvider>

--- a/src/lib/seam/use-seam-client.ts
+++ b/src/lib/seam/use-seam-client.ts
@@ -102,10 +102,10 @@ This is not recommended because the client session is now bound to this machine 
   }
 
   const fingerprint =
-    globalThis?.localStorage?.getItem('seam_user_fingerprint') ??
+    globalThis.localStorage?.getItem('seam_user_fingerprint') ??
     `fingerprint_${uuidv4()}`
 
-  globalThis?.localStorage?.setItem('seam_user_fingerprint', fingerprint)
+  globalThis.localStorage?.setItem('seam_user_fingerprint', fingerprint)
 
   return fingerprint
 }

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -47,8 +47,7 @@ export function Menu({
   const [left, setLeft] = useState(0)
 
   useEffect(() => {
-    const containers =
-      globalThis.document?.querySelectorAll('.seam-components')
+    const containers = globalThis.document?.querySelectorAll('.seam-components')
     if (containers == null) return
     const el = containers[containers.length - 1]
     if (el != null) {

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -48,7 +48,7 @@ export function Menu({
 
   useEffect(() => {
     const containers =
-      globalThis?.document?.querySelectorAll('.seam-components')
+      globalThis.document?.querySelectorAll('.seam-components')
     if (containers == null) return
     const el = containers[containers.length - 1]
     if (el != null) {
@@ -110,11 +110,11 @@ export function Menu({
 
   useLayoutEffect(() => {
     setPositions()
-    globalThis?.addEventListener('scroll', setPositions)
-    globalThis?.addEventListener('resize', setPositions)
+    globalThis.addEventListener('scroll', setPositions)
+    globalThis.addEventListener('resize', setPositions)
     return () => {
-      globalThis?.removeEventListener('scroll', setPositions)
-      globalThis?.removeEventListener('resize', setPositions)
+      globalThis.removeEventListener('scroll', setPositions)
+      globalThis.removeEventListener('resize', setPositions)
     }
   }, [setPositions])
 

--- a/src/lib/ui/clipboard.ts
+++ b/src/lib/ui/clipboard.ts
@@ -1,3 +1,3 @@
 export async function copyToClipboard(value: string): Promise<void> {
-  await globalThis?.navigator?.clipboard?.writeText(value)
+  await globalThis.navigator?.clipboard?.writeText(value)
 }


### PR DESCRIPTION
This was inconsistent. I think we can just assume `globalThis` is defined vs the other way of putting the `?.` everywhere.