### PR TITLE
Disable `operator-no-newline-after` in Stylelint

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": ["stylelint-config-standard-scss"],
   "rules": {
-    "no-descending-specificity": null
+    "no-descending-specificity": null,
+    "operator-no-newline-after": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,6 +2,6 @@
   "extends": ["stylelint-config-standard-scss"],
   "rules": {
     "no-descending-specificity": null,
-    "operator-no-newline-after": null
+    "scss/operator-no-newline-after": null
   }
 }


### PR DESCRIPTION
Disables the `scss/operator-no-newline-after` stylelint rule since this will conflict with the formatter for longer lines (which aren't very common in SCSS except for, usually, math ops).

