### PR TITLE
Fix `Tooltip` icon layout

### DIFF
--- a/src/styles/_tooltip.scss
+++ b/src/styles/_tooltip.scss
@@ -21,6 +21,9 @@
 
       & .seam-tooltip-button-icon {
         position: absolute;
+        display: flex;
+        justify-content: center;
+        align-items: center;
         transition: opacity 0.15s ease-in-out;
       }
 


### PR DESCRIPTION
Minor fix to the layout of the tooltip button icon—was a bit off when used in ref to other components