### PR TITLE
Fixed font for `AccordionRow`

### DIFF
--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -108,7 +108,7 @@
 @mixin accordion-row {
   .seam-accordion-row {
     overflow: hidden;
-   
+
     .seam-accordion-row-trigger {
       appearance: none;
       width: 100%;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -108,7 +108,7 @@
 @mixin accordion-row {
   .seam-accordion-row {
     overflow: hidden;
-
+   
     .seam-accordion-row-trigger {
       appearance: none;
       width: 100%;
@@ -117,6 +117,7 @@
       border: none;
       box-shadow: none;
       cursor: pointer;
+      font-family: inherit;
     }
 
     .seam-accordion-row-content {


### PR DESCRIPTION
It looks like the browser had some of its own styles for buttons, so it was necessary to add this css rule here. 