### PR TITLE
Make `label` optional for `DetailSection`

### DIFF
--- a/src/lib/ui/layout/DetailSection.tsx
+++ b/src/lib/ui/layout/DetailSection.tsx
@@ -3,7 +3,7 @@ import type { PropsWithChildren } from 'react'
 import { Tooltip } from 'lib/ui/Tooltip/Tooltip.js'
 
 interface DetailSectionProps {
-  label: string
+  label?: string
   tooltipContent?: string
 }
 
@@ -15,8 +15,8 @@ export function DetailSection({
   return (
     <div className='seam-detail-section'>
       <div className='seam-detail-label-wrap'>
-        <p className='seam-detail-label'>{label}</p>
-        {tooltipContent != null && <Tooltip>{tooltipContent}</Tooltip>}
+        {label !== undefined && <p className='seam-detail-label'>{label}</p>}
+        {tooltipContent !== undefined && <Tooltip>{tooltipContent}</Tooltip>}
       </div>
 
       <div className='seam-detail-group'>{children}</div>

--- a/src/lib/ui/layout/DetailSection.tsx
+++ b/src/lib/ui/layout/DetailSection.tsx
@@ -15,8 +15,8 @@ export function DetailSection({
   return (
     <div className='seam-detail-section'>
       <div className='seam-detail-label-wrap'>
-        {label !== undefined && <p className='seam-detail-label'>{label}</p>}
-        {tooltipContent !== undefined && <Tooltip>{tooltipContent}</Tooltip>}
+        {label != null && <p className='seam-detail-label'>{label}</p>}
+        {tooltipContent != null && <Tooltip>{tooltipContent}</Tooltip>}
       </div>
 
       <div className='seam-detail-group'>{children}</div>

--- a/src/lib/ui/layout/DetailSectionGroup.stories.tsx
+++ b/src/lib/ui/layout/DetailSectionGroup.stories.tsx
@@ -28,7 +28,7 @@ export const Content: Story = {
           <DetailRow label='Row 3' />
         </DetailSection>
 
-        <DetailSection label='Section 3'>
+        <DetailSection>
           <DetailRow label='Row 1' />
           <DetailRow label='Row 2' />
           <DetailRow label='Row 3' />


### PR DESCRIPTION
`ClimateSettingScheduleDetails` has sections without labels

<img width="500" alt="Screenshot 2023-08-31 at 12 25 09 PM" src="https://github.com/seamapi/react/assets/11382084/8390cabc-08f1-4ff7-97de-2fb4cbadd0e7">
