### PR TITLE
Rename story section from Example to Components

### DIFF
--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.stories.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.stories.tsx
@@ -8,7 +8,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
  * These stories showcase access code details.
  */
 const meta: Meta<typeof AccessCodeDetails> = {
-  title: 'Example/AccessCodeDetails',
+  title: 'Components/AccessCodeDetails',
   component: AccessCodeDetails,
   tags: ['autodocs'],
   parameters: {

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.stories.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.stories.tsx
@@ -8,7 +8,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
  * These stories showcase the access code table.
  */
 const meta: Meta<typeof AccessCodeTable> = {
-  title: 'Example/AccessCodeTable',
+  title: 'Components/AccessCodeTable',
   component: AccessCodeTable,
   tags: ['autodocs'],
   parameters: {

--- a/src/lib/seam/components/ClimateSettingScheduleDetails/ClimateSettingScheduleDetails.stories.tsx
+++ b/src/lib/seam/components/ClimateSettingScheduleDetails/ClimateSettingScheduleDetails.stories.tsx
@@ -5,7 +5,7 @@ import { ClimateSettingScheduleDetails } from 'lib/seam/components/ClimateSettin
 import { useToggle } from 'lib/ui/use-toggle.js'
 
 const meta: Meta<typeof ClimateSettingScheduleDetails> = {
-  title: 'Example/ClimateSettingScheduleDetails',
+  title: 'Components/ClimateSettingScheduleDetails',
   component: ClimateSettingScheduleDetails,
   tags: ['autodocs'],
   parameters: {

--- a/src/lib/seam/components/ClimateSettingScheduleTable/ClimateSettingScheduleTable.stories.tsx
+++ b/src/lib/seam/components/ClimateSettingScheduleTable/ClimateSettingScheduleTable.stories.tsx
@@ -6,7 +6,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
 import { ClimateSettingScheduleTable } from './ClimateSettingScheduleTable.js'
 
 const meta: Meta<typeof ClimateSettingScheduleTable> = {
-  title: 'Example/ClimateSettingScheduleTable',
+  title: 'Components/ClimateSettingScheduleTable',
   component: ClimateSettingScheduleTable,
   tags: ['autodocs'],
   parameters: {

--- a/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.stories.tsx
+++ b/src/lib/seam/components/ConnectAccountButton/ConnectAccountButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ConnectAccountButton } from 'lib/seam/components/ConnectAccountButton/ConnectAccountButton.js'
 
 const meta: Meta<typeof ConnectAccountButton> = {
-  title: 'Example/ConnectAccountButton',
+  title: 'Components/ConnectAccountButton',
   component: ConnectAccountButton,
   tags: ['autodocs'],
 }

--- a/src/lib/seam/components/CreateAccessCodeForm/CreateAccessCodeForm.stories.tsx
+++ b/src/lib/seam/components/CreateAccessCodeForm/CreateAccessCodeForm.stories.tsx
@@ -8,7 +8,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
  * Coming soon.
  */
 const meta: Meta<typeof CreateAccessCodeForm> = {
-  title: 'Example/CreateAccessCodeForm',
+  title: 'Components/CreateAccessCodeForm',
   component: CreateAccessCodeForm,
   tags: ['autodocs'],
   parameters: {

--- a/src/lib/seam/components/DeviceDetails/DeviceDetails.stories.tsx
+++ b/src/lib/seam/components/DeviceDetails/DeviceDetails.stories.tsx
@@ -9,7 +9,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
  * These stories showcase the device details.
  */
 const meta: Meta<typeof DeviceDetails> = {
-  title: 'Example/DeviceDetails',
+  title: 'Components/DeviceDetails',
   component: DeviceDetails,
   tags: ['autodocs'],
   parameters: {

--- a/src/lib/seam/components/DeviceTable/DeviceTable.stories.tsx
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.stories.tsx
@@ -8,7 +8,7 @@ import {
 import { useToggle } from 'lib/ui/use-toggle.js'
 
 const meta: Meta<typeof DeviceTable> = {
-  title: 'Example/DeviceTable',
+  title: 'Components/DeviceTable',
   component: DeviceTable,
   tags: ['autodocs'],
   parameters: {

--- a/src/lib/seam/components/EditAccessCodeForm/EditAccessCodeForm.stories.tsx
+++ b/src/lib/seam/components/EditAccessCodeForm/EditAccessCodeForm.stories.tsx
@@ -8,7 +8,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
  * These stories showcase editing an access code.
  */
 const meta: Meta<typeof EditAccessCodeForm> = {
-  title: 'Example/EditAccessCodeForm',
+  title: 'Components/EditAccessCodeForm',
   component: EditAccessCodeForm,
   tags: ['autodocs'],
   parameters: {

--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDevice.stories.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDevice.stories.tsx
@@ -8,7 +8,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
  * These stories showcase the supported devices table.
  */
 const meta: Meta<typeof SupportedDeviceTable> = {
-  title: 'Example/SupportedDeviceTable',
+  title: 'Components/SupportedDeviceTable',
   component: SupportedDeviceTable,
   tags: ['autodocs'],
   parameters: {


### PR DESCRIPTION
This will require find/replace on the api-docs repo, but long term I think it makes more sense. Holding off on merge until next week.


See https://github.com/seamapi/api-docs/pull/177