### PR TITLE
Fix `ChevronDownIcon` mask ref

### DIFF
--- a/assets/icons/chevron-down.svg
+++ b/assets/icons/chevron-down.svg
@@ -1,8 +1,8 @@
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<mask style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
+	<mask id="chevron-down" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="20" height="20">
 		<rect width="20" height="20" fill="#D9D9D9"/>
 	</mask>
-	<g mask="url(#mask0_1045_100036)">
+	<g mask="url(#chevron-down)">
 		<path d="M10 12.8127L5 7.81266L6.16667 6.646L10 10.4793L13.8333 6.646L15 7.81266L10 12.8127Z" fill="#6E7179"/>
 	</g>
 </svg>

--- a/src/lib/icons/ChevronDown.tsx
+++ b/src/lib/icons/ChevronDown.tsx
@@ -12,7 +12,20 @@ export function ChevronDownIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
       fill='none'
       {...props}
     >
-      <g mask='url(#chevron-down_svg__mask0_1045_100036)'>
+      <mask
+        id='chevron-down_svg__a'
+        width={20}
+        height={20}
+        x={0}
+        y={0}
+        maskUnits='userSpaceOnUse'
+        style={{
+          maskType: 'alpha',
+        }}
+      >
+        <path fill='#D9D9D9' d='M0 0h20v20H0z' />
+      </mask>
+      <g mask='url(#chevron-down_svg__a)'>
         <path
           fill='#6E7179'
           d='m10 12.813-5-5 1.167-1.167L10 10.479l3.833-3.833L15 7.813l-5 5Z'


### PR DESCRIPTION
Same issue as #443 • Different browsers have different policies about this, it seems.