### PR TITLE
fix: Custom element name conflict with CreateAccessCodeForm 

### DIFF
--- a/src/lib/seam/components/EditAccessCodeForm/EditAccessCodeForm.element.ts
+++ b/src/lib/seam/components/EditAccessCodeForm/EditAccessCodeForm.element.ts
@@ -1,7 +1,7 @@
 import type { ElementProps } from 'lib/element.js'
 import type { EditAccessCodeFormProps } from 'lib/seam/components/EditAccessCodeForm/EditAccessCodeForm.js'
 
-export const name = 'seam-create-access-code-form'
+export const name = 'seam-edit-access-code-form'
 
 export const props: ElementProps<EditAccessCodeFormProps> = {
   accessCodeId: 'string',


### PR DESCRIPTION
The same name was used for both CreateAccessCodeForm and EditAccessCodeForm, causing this error when trying to use native web components:

Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': the name "seam-access-code-details" has already been used with this registry
    at yO (https://react.seam.co/v/1.55.0/dist/elements.js:8251:48)
    at https://react.seam.co/v/1.55.0/dist/elements.js:28109:15
