### PR TITLE
fix(Menu/Dropdown): incorrect position in storybook/docs

### DIFF
--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -69,11 +69,10 @@ export function Menu({
     const { right: containerRight, bottom: containerBottom } =
       documentEl.getBoundingClientRect()
 
-    const {
-      top: anchorTop,
-      left: anchorLeft,
-      height: anchorHeight,
-    } = anchorEl.getBoundingClientRect()
+    const { height: anchorHeight } = anchorEl.getBoundingClientRect()
+
+    const anchorTop = anchorEl.offsetTop
+    const anchorLeft = anchorEl.offsetLeft
 
     const { width: contentWidth, height: contentHeight } =
       contentEl.getBoundingClientRect()


### PR DESCRIPTION
fixes #424 

Messed with iframe calculations a bunch, but the fix was much simpler, just use `offsetTop` instead of `getBoundingClientRect`

https://github.com/seamapi/react/assets/11449462/693b0782-670e-41f4-b677-b8d8547a3876

