### PR TITLE
Menu fixes

### DIFF
--- a/src/lib/icons/ChevronDown.tsx
+++ b/src/lib/icons/ChevronDown.tsx
@@ -13,7 +13,6 @@ export function ChevronDownIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
       {...props}
     >
       <mask
-        id='chevron-down_svg__a'
         width={20}
         height={20}
         x={0}
@@ -25,7 +24,7 @@ export function ChevronDownIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
       >
         <path fill='#D9D9D9' d='M0 0h20v20H0z' />
       </mask>
-      <g mask='url(#chevron-down_svg__a)'>
+      <g>
         <path
           fill='#6E7179'
           d='m10 12.813-5-5 1.167-1.167L10 10.479l3.833-3.833L15 7.813l-5 5Z'

--- a/src/lib/icons/ChevronDown.tsx
+++ b/src/lib/icons/ChevronDown.tsx
@@ -13,6 +13,7 @@ export function ChevronDownIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
       {...props}
     >
       <mask
+        id='chevron-down_svg__a'
         width={20}
         height={20}
         x={0}
@@ -24,7 +25,7 @@ export function ChevronDownIcon(props: SVGProps<SVGSVGElement>): JSX.Element {
       >
         <path fill='#D9D9D9' d='M0 0h20v20H0z' />
       </mask>
-      <g>
+      <g mask='url(#chevron-down_svg__a)'>
         <path
           fill='#6E7179'
           d='m10 12.813-5-5 1.167-1.167L10 10.479l3.833-3.833L15 7.813l-5 5Z'

--- a/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
@@ -36,7 +36,10 @@ export function FilterCategoryMenu({
   onAllOptionSelect,
   buttonLabel,
 }: FilterCategoryMenuProps): JSX.Element {
-  const usableOptions = hideAllOption ? options : [allLabel, ...options]
+  const sortedOptions = [...options].sort((a, b) => a.localeCompare(b))
+  const usableOptions = hideAllOption
+    ? sortedOptions
+    : [allLabel, ...sortedOptions]
 
   return (
     <div className='seam-supported-device-table-filter-menu-wrap'>
@@ -50,32 +53,20 @@ export function FilterCategoryMenu({
         )}
       >
         <div className='seam-supported-device-table-filter-menu-content'>
-          {usableOptions
-            .sort((a, b) => {
-              // Always put 'All' first
-              if (a === allLabel) {
-                return -1
-              }
-              if (b === allLabel) {
-                return 1
-              }
-
-              return a.localeCompare(b)
-            })
-            .map((option, index) => (
-              <MenuItem
-                key={`${index}:${option}`}
-                onClick={() => {
-                  if (option === allLabel) {
-                    onAllOptionSelect?.()
-                  } else {
-                    onSelect(option)
-                  }
-                }}
-              >
-                <span>{option}</span>
-              </MenuItem>
-            ))}
+          {usableOptions.map((option, index) => (
+            <MenuItem
+              key={`${index}:${option}`}
+              onClick={() => {
+                if (option === allLabel) {
+                  onAllOptionSelect?.()
+                } else {
+                  onSelect(option)
+                }
+              }}
+            >
+              <span>{option}</span>
+            </MenuItem>
+          ))}
         </div>
       </Menu>
     </div>

--- a/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
@@ -49,20 +49,22 @@ export function FilterCategoryMenu({
           </button>
         )}
       >
-        {usableOptions.map((option, index) => (
-          <MenuItem
-            key={`${index}:${option}`}
-            onClick={() => {
-              if (option === allLabel) {
-                onAllOptionSelect?.()
-              } else {
-                onSelect(option)
-              }
-            }}
-          >
-            <span>{option}</span>
-          </MenuItem>
-        ))}
+        <div className='seam-supported-device-table-filter-menu-content'>
+          {usableOptions.map((option, index) => (
+            <MenuItem
+              key={`${index}:${option}`}
+              onClick={() => {
+                if (option === allLabel) {
+                  onAllOptionSelect?.()
+                } else {
+                  onSelect(option)
+                }
+              }}
+            >
+              <span>{option}</span>
+            </MenuItem>
+          ))}
+        </div>
       </Menu>
     </div>
   )

--- a/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
@@ -42,8 +42,8 @@ export function FilterCategoryMenu({
     <div className='seam-supported-device-table-filter-menu-wrap'>
       <p>{label}</p>
       <Menu
-        renderButton={({ onOpen }) => (
-          <button onClick={onOpen}>
+        renderButton={({ onOpen, ref }) => (
+          <button onClick={onOpen} ref={ref}>
             <span>{buttonLabel}</span>
             <ChevronDownIcon />
           </button>

--- a/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
@@ -50,20 +50,32 @@ export function FilterCategoryMenu({
         )}
       >
         <div className='seam-supported-device-table-filter-menu-content'>
-          {usableOptions.map((option, index) => (
-            <MenuItem
-              key={`${index}:${option}`}
-              onClick={() => {
-                if (option === allLabel) {
-                  onAllOptionSelect?.()
-                } else {
-                  onSelect(option)
-                }
-              }}
-            >
-              <span>{option}</span>
-            </MenuItem>
-          ))}
+          {usableOptions
+            .sort((a, b) => {
+              // Always put 'All' first
+              if (a === allLabel) {
+                return -1
+              }
+              if (b === allLabel) {
+                return 1
+              }
+
+              return a.localeCompare(b)
+            })
+            .map((option, index) => (
+              <MenuItem
+                key={`${index}:${option}`}
+                onClick={() => {
+                  if (option === allLabel) {
+                    onAllOptionSelect?.()
+                  } else {
+                    onSelect(option)
+                  }
+                }}
+              >
+                <span>{option}</span>
+              </MenuItem>
+            ))}
         </div>
       </Menu>
     </div>

--- a/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/FilterCategoryMenu.tsx
@@ -42,8 +42,8 @@ export function FilterCategoryMenu({
     <div className='seam-supported-device-table-filter-menu-wrap'>
       <p>{label}</p>
       <Menu
-        renderButton={({ onOpen, ref }) => (
-          <button onClick={onOpen} ref={ref}>
+        renderButton={({ onOpen }) => (
+          <button onClick={onOpen}>
             <span>{buttonLabel}</span>
             <ChevronDownIcon />
           </button>

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -54,8 +54,8 @@ export function Menu({
     setDocumentEl(documentEl)
 
     const bodyElements = documentEl?.getElementsByTagName('body')
-    if (bodyElements.length === 0) return
-    setBodyEl(bodyElements[0] as HTMLElement)
+    if (bodyElements[0] == null) return
+    setBodyEl(bodyElements[0])
   }, [setDocumentEl])
 
   const handleClose = (): void => {

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -102,9 +102,11 @@ export function Menu({
 
     // If the content would overflow bottom, position it above the anchor.
     const isOverFlowingBottom = bottom > containerBottom
-    const visibleTop = isOverFlowingBottom
-      ? anchorTop - contentHeight - verticalOffset
-      : top
+    const topWhenAboveAnchor = anchorTop - contentHeight - verticalOffset
+
+    // We only want to open the menu above the anchor if it won't get clipped, ie. not < 0.
+    const visibleTop =
+      isOverFlowingBottom && topWhenAboveAnchor > 0 ? topWhenAboveAnchor : top
     setTop(visibleTop)
   }, [
     anchorEl,

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -19,6 +19,7 @@ export interface MenuProps extends PropsWithChildren {
   edgeOffset?: number
   renderButton: (props: {
     onOpen: (event: MouseEvent<HTMLElement>) => void
+    ref: (button: HTMLButtonElement) => void
   }) => JSX.Element
   backgroundProps?: Partial<{
     className?: string
@@ -48,7 +49,17 @@ export function Menu({
   const [top, setTop] = useState(0)
   const [left, setLeft] = useState(0)
 
+  const [buttonEl, setButtonEl] = useState<null | HTMLButtonElement>(null)
+
   useEffect(() => {
+    if (buttonEl != null) {
+      const parent = buttonEl?.closest(`.${seamComponentsClassName}`)
+      if (parent == null) return
+      setDocumentEl(parent)
+
+      return
+    }
+
     const containers = globalThis.document?.querySelectorAll(
       `.${seamComponentsClassName}`
     )
@@ -57,7 +68,7 @@ export function Menu({
     if (el != null) {
       setDocumentEl(el)
     }
-  }, [setDocumentEl])
+  }, [setDocumentEl, buttonEl])
 
   const handleClose = (): void => {
     setAnchorEl(null)
@@ -134,7 +145,7 @@ export function Menu({
         close: handleClose,
       }}
     >
-      {renderButton({ onOpen: handleOpen })}
+      {renderButton({ onOpen: handleOpen, ref: setButtonEl })}
       {createPortal(
         <div
           className={classNames(

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -42,12 +42,12 @@ export function Menu({
   backgroundProps,
 }: MenuProps): JSX.Element | null {
   const { Provider } = menuContext
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [documentEl, setDocumentEl] = useState<null | HTMLElement>(null)
+  const [bodyEl, setBodyEl] = useState<null | HTMLElement>(null)
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [contentEl, setContentEl] = useState<HTMLDivElement | null>(null)
   const [top, setTop] = useState(0)
   const [left, setLeft] = useState(0)
-  const [bodyEl, setBodyEl] = useState<null | HTMLElement>(null)
 
   useEffect(() => {
     const documentEl = globalThis.document.documentElement
@@ -70,16 +70,17 @@ export function Menu({
     if (
       anchorEl == null ||
       contentEl == null ||
-      documentEl == null ||
-      bodyEl == null
+      bodyEl == null ||
+      documentEl == null
     )
       return
 
-    const containerRight = documentEl.offsetLeft + documentEl.offsetWidth
-    const containerBottom = documentEl.offsetTop + documentEl.offsetHeight
+    const containerRight = documentEl.offsetLeft + documentEl.clientWidth
+    const containerBottom = documentEl.offsetTop + documentEl.clientHeight
 
-    const anchorTop = anchorEl.offsetTop
-    const anchorLeft = anchorEl.offsetLeft
+    const anchorBox = anchorEl.getBoundingClientRect()
+    const anchorTop = anchorBox.top + bodyEl.clientTop
+    const anchorLeft = anchorBox.left + bodyEl.clientLeft
     const anchorHeight = anchorEl.offsetHeight
 
     const contentWidth = contentEl.offsetWidth
@@ -110,9 +111,9 @@ export function Menu({
     horizontalOffset,
     verticalOffset,
     contentEl,
-    documentEl,
     edgeOffset,
     bodyEl,
+    documentEl,
   ])
 
   useLayoutEffect(() => {

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -50,7 +50,7 @@ export function Menu({
 
   useEffect(() => {
     const containers = globalThis.document?.querySelectorAll(
-      seamComponentsClassName
+      `.${seamComponentsClassName}`
     )
     if (containers == null) return
     const el = containers[containers.length - 1]

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -104,7 +104,7 @@ export function Menu({
     const isOverFlowingBottom = bottom > containerBottom
     const topWhenAboveAnchor = anchorTop - contentHeight - verticalOffset
 
-    // We only want to open the menu above the anchor if it won't get clipped, ie. not < 0.
+    // Only open the menu above the anchor if it won't get clipped, i.e., not < 0.
     const visibleTop =
       isOverFlowingBottom && topWhenAboveAnchor > 0 ? topWhenAboveAnchor : top
     setTop(visibleTop)

--- a/src/styles/_supported-device-table.scss
+++ b/src/styles/_supported-device-table.scss
@@ -372,4 +372,9 @@ $row-padding: 8px;
       align-items: center;
     }
   }
+
+  .seam-supported-device-table-filter-menu-content {
+    max-height: 300px;
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
Closes #425 

See [commits](https://github.com/seamapi/react/pull/503/commits) for list of changes.

### Notable things

- Now calculating container dimensions via `body` which doesn't change depending on content.

### Demo

https://github.com/seamapi/react/assets/11449462/bce78d7b-9f65-4875-a240-f87c45d436e7

- **Filter** button is showing again.
- Opening nested menu will align to correct anchor.
- Multiple menus in storybook still open / are positioned correctly.
- Menus only open up if there is enough space. No clipping.
- Opening a menu after scrolling (and while scrolling) still positions the menu correctly.