### PR TITLE
fix(SupportedDeviceTable): set white bg to always match fade white overlay

### DIFF
--- a/src/styles/_supported-device-table.scss
+++ b/src/styles/_supported-device-table.scss
@@ -3,6 +3,10 @@
 $row-padding: 8px;
 
 @mixin all {
+  .seam-supported-device-table-content-wrap {
+    background: colors.$white;
+  }
+
   .seam-supported-device-table-filter-area {
     width: 100%;
     display: flex;


### PR DESCRIPTION
fixes #420 

#### Before

![image](https://github.com/seamapi/react/assets/11449462/c22f3fcf-e6c6-4725-8009-9468a367bf6d)

#### After

![image](https://github.com/seamapi/react/assets/11449462/45955dcc-3004-42c4-93b8-a6459d690658)

