### PR TITLE
test: Simulate outages

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -46,7 +46,6 @@ const preview: Preview = {
       description: 'Simulate an outage',
       defaultValue: false,
       toolbar: {
-        icon: 'lightning',
         items: [
           { value: false, icon: 'lightning', title: 'Normal' },
           { value: true, icon: 'lightningoff', title: 'Outage' },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -48,8 +48,8 @@ const preview: Preview = {
       toolbar: {
         icon: 'circlehollow',
         items: [
-          { value: false, icon: 'circlehollow', title: 'Normal' },
-          { value: true, icon: 'circle', title: 'Outage' },
+          { value: false, icon: 'lightning', title: 'Normal' },
+          { value: true, icon: 'lightningoff', title: 'Outage' },
         ],
       },
     },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -44,11 +44,11 @@ const preview: Preview = {
     },
     simulatedOutage: {
       description: 'Simulate an outage',
-      defaultValue: false,
+      defaultValue: 'normal',
       toolbar: {
         items: [
-          { value: false, icon: 'lightning', title: 'Normal' },
-          { value: true, icon: 'lightningoff', title: 'Outage' },
+          { value: 'normal', icon: 'lightning', title: 'Normal' },
+          { value: 'outage', icon: 'lightningoff', title: 'Outage' },
         ],
       },
     },
@@ -77,7 +77,7 @@ const preview: Preview = {
       return (
         <SeamProvider
           publishableKey={
-            simulatedOutage !== null ? 'seam_pk_3' : publishableKey
+            simulatedOutage === 'outage' ? 'seam_pk_3' : publishableKey
           }
           userIdentifierKey={userIdentifierKey}
           endpoint={seamEndpoint}

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -46,7 +46,7 @@ const preview: Preview = {
       description: 'Simulate an outage',
       defaultValue: false,
       toolbar: {
-        icon: 'circlehollow',
+        icon: 'lightning',
         items: [
           { value: false, icon: 'lightning', title: 'Normal' },
           { value: true, icon: 'lightningoff', title: 'Outage' },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -77,7 +77,9 @@ const preview: Preview = {
     ) => {
       return (
         <SeamProvider
-          publishableKey={simulatedOutage ? 'seam_pk_3' : publishableKey}
+          publishableKey={
+            simulatedOutage !== null ? 'seam_pk_3' : publishableKey
+          }
           userIdentifierKey={userIdentifierKey}
           endpoint={seamEndpoint}
           disableCssInjection

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -42,6 +42,17 @@ const preview: Preview = {
       description: 'Seam Endpoint',
       defaultValue: process.env['STORYBOOK_SEAM_ENDPOINT'] ?? '/api',
     },
+    simulatedOutage: {
+      description: 'Simulate an outage',
+      defaultValue: false,
+      toolbar: {
+        icon: 'circlehollow',
+        items: [
+          { value: false, icon: 'circlehollow', title: 'Normal' },
+          { value: true, icon: 'circle', title: 'Outage' },
+        ],
+      },
+    },
   },
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
@@ -55,11 +66,18 @@ const preview: Preview = {
   decorators: [
     (
       Story,
-      { globals: { publishableKey, userIdentifierKey, seamEndpoint } }
+      {
+        globals: {
+          publishableKey,
+          userIdentifierKey,
+          seamEndpoint,
+          simulatedOutage,
+        },
+      }
     ) => {
       return (
         <SeamProvider
-          publishableKey={publishableKey}
+          publishableKey={simulatedOutage ? 'seam_pk_3' : publishableKey}
           userIdentifierKey={userIdentifierKey}
           endpoint={seamEndpoint}
           disableCssInjection

--- a/.storybook/seed-fake.js
+++ b/.storybook/seed-fake.js
@@ -12,9 +12,17 @@ export const seedFake = (db) => {
     created_at: '2023-05-15T14:07:48.000',
   })
 
+  const ws3 = db.addWorkspace({
+    name: 'Seed Workspace 3 (simulated outage)',
+    publishable_key: 'seam_pk_3',
+    created_at: '2023-05-15T14:07:48.000',
+  })
+
+  db.simulateWorkspaceOutage(ws3.workspace_id)
+
   const cw = db.addConnectWebview({
     workspace_id: ws2.workspace_id,
-    created_at: '2023-05-15T15:08:49.000',
+    created_at: '2023-10-03T15:07:48.000',
   })
 
   const ca = db.addConnectedAccount({

--- a/.storybook/seed-fake.js
+++ b/.storybook/seed-fake.js
@@ -22,7 +22,7 @@ export const seedFake = (db) => {
 
   const cw = db.addConnectWebview({
     workspace_id: ws2.workspace_id,
-    created_at: '2023-10-03T15:07:48.000',
+    created_at: '2023-05-15T15:08:49.000',
   })
 
   const ca = db.addConnectedAccount({

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.12.2",
         "@rxfork/r2wc-react-to-web-component": "^2.3.0",
-        "@seamapi/fake-seam-connect": "^1.16.0",
+        "@seamapi/fake-seam-connect": "^1.17.0",
         "@storybook/addon-designs": "^7.0.1",
         "@storybook/addon-essentials": "^7.0.2",
         "@storybook/addon-links": "^7.0.2",
@@ -4500,11 +4500,10 @@
       }
     },
     "node_modules/@seamapi/fake-seam-connect": {
-      "version": "1.16.0",
-      "resolved": "https://npm.pkg.github.com/download/@seamapi/fake-seam-connect/1.16.0/4b39eb2ebe4d282e72c853395a8c1c2f7772b2a2",
-      "integrity": "sha512-FMnYhMDMLI8BQdmKYFoctekeh+JLAmY/Kn+8MJ+YoxDm5SODgwzu0AjBwcuc8zjqmX4pG9psvkXQ2ZDynwuUGQ==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-1.17.0.tgz",
+      "integrity": "sha512-WKZ0HUI6y5Q025rMh1It15i8JMz8gXoC3Km81NNss0R0Jl5ubMNGKlUOO1MetXkhTc5pa3i1ARORS/AXYZ94HQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "fake-seam-connect": "dist/server.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.12.2",
         "@rxfork/r2wc-react-to-web-component": "^2.3.0",
-        "@seamapi/fake-seam-connect": "^1.14.0",
+        "@seamapi/fake-seam-connect": "^1.16.0",
         "@storybook/addon-designs": "^7.0.1",
         "@storybook/addon-essentials": "^7.0.2",
         "@storybook/addon-links": "^7.0.2",
@@ -4500,10 +4500,11 @@
       }
     },
     "node_modules/@seamapi/fake-seam-connect": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@seamapi/fake-seam-connect/-/fake-seam-connect-1.15.0.tgz",
-      "integrity": "sha512-BsHq/SetsHkQw/eS/nk9AlRRHTaiQUEQ3sfwNrTVoLyqkkt3AXtdhvMrj7K/cHAK8nu/kVYXgJPbwJRSfGCz5g==",
+      "version": "1.16.0",
+      "resolved": "https://npm.pkg.github.com/download/@seamapi/fake-seam-connect/1.16.0/4b39eb2ebe4d282e72c853395a8c1c2f7772b2a2",
+      "integrity": "sha512-FMnYhMDMLI8BQdmKYFoctekeh+JLAmY/Kn+8MJ+YoxDm5SODgwzu0AjBwcuc8zjqmX4pG9psvkXQ2ZDynwuUGQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "fake-seam-connect": "dist/server.js"
       },

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.2",
     "@rxfork/r2wc-react-to-web-component": "^2.3.0",
-    "@seamapi/fake-seam-connect": "^1.16.0",
+    "@seamapi/fake-seam-connect": "^1.17.0",
     "@storybook/addon-designs": "^7.0.1",
     "@storybook/addon-essentials": "^7.0.2",
     "@storybook/addon-links": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.2",
     "@rxfork/r2wc-react-to-web-component": "^2.3.0",
-    "@seamapi/fake-seam-connect": "^1.14.0",
+    "@seamapi/fake-seam-connect": "^1.16.0",
     "@storybook/addon-designs": "^7.0.1",
     "@storybook/addon-essentials": "^7.0.2",
     "@storybook/addon-links": "^7.0.2",

--- a/src/lib/seam/components/DeviceTable/DeviceTable.stories.tsx
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.stories.tsx
@@ -69,3 +69,10 @@ export const ReadOnlyCustomerSupportPanel: Story = {
     />
   ),
 }
+
+export const SimulatedOutage: Story = {
+  render: ({ onBack, ...props } = {}) => <DeviceTable {...props} />,
+  parameters: {
+    globals: { simulatedOutage: true },
+  },
+}

--- a/src/lib/seam/components/DeviceTable/DeviceTable.stories.tsx
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.stories.tsx
@@ -69,10 +69,3 @@ export const ReadOnlyCustomerSupportPanel: Story = {
     />
   ),
 }
-
-export const SimulatedOutage: Story = {
-  render: ({ onBack, ...props } = {}) => <DeviceTable {...props} />,
-  parameters: {
-    globals: { simulatedOutage: true },
-  },
-}

--- a/test/fixtures/seed-fake.ts
+++ b/test/fixtures/seed-fake.ts
@@ -9,6 +9,9 @@ interface Seed {
 export const seedFake = async (db: Database): Promise<Seed> => {
   const ws1 = db.addWorkspace({ name: 'Seed Workspace 1 (starts empty)' })
   const ws2 = db.addWorkspace({ name: 'Seed Workspace 2 (starts populated)' })
+  const ws3 = db.addWorkspace({ name: 'Seed Workspace 3 (simulated outage)' })
+
+  db.simulateWorkspaceOutage(ws3.workspace_id)
 
   const cw = db.addConnectWebview({
     workspace_id: ws2.workspace_id,


### PR DESCRIPTION
Adds the ability to simulate outages by toggling between publishable keys.

<img width="1297" alt="Screenshot 2023-10-03 at 6 31 13 PM" src="https://github.com/seamapi/react/assets/87919558/3baeb1ad-ab1d-4489-ba84-94d886eb5abe">

---

Note: Going from `Normal` to `Outage` sometimes requires a reload. Any ideas on how we can eliminate this?
