### PR TITLE
fix: Remove tooltip device details in `ThermostatDeviceDetails`

### DIFF
--- a/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
@@ -128,10 +128,7 @@ export function ThermostatDeviceDetails(
               </DetailRow>
             </DetailSection>
 
-            <DetailSection
-              label={t.deviceDetails}
-              tooltipContent={t.deviceDetailsTooltip}
-            >
+            <DetailSection label={t.deviceDetails}>
               <DetailRow label={t.brand}>
                 <div className='seam-detail-row-hstack'>
                   {device.properties.model.manufacturer_display_name}
@@ -172,8 +169,6 @@ const t = {
   defaultClimate: 'Default climate',
   allowManualOverride: 'Allow manual override',
   deviceDetails: 'Device details',
-  deviceDetailsTooltip:
-    'When a scheduled climate reaches its end time, the default settings will kick in.',
   brand: 'Brand',
   linkedAccount: 'Linked account',
   deviceId: 'Device ID',


### PR DESCRIPTION
The design does not have a tooltip for device details