### PR TITLE
fix(AccessCode): stale data after update

### DIFF
--- a/src/lib/seam/access-codes/use-update-access-code.ts
+++ b/src/lib/seam/access-codes/use-update-access-code.ts
@@ -64,9 +64,7 @@ export function useUpdateAccessCode(): UseMutationResult<
           }
 
           return accessCodes.map((accessCode) => {
-            const isTarget =
-              accessCode.access_code_id === variables.access_code_id
-            if (isTarget) {
+            if (accessCode.access_code_id === variables.access_code_id) {
               return {
                 ...accessCode,
                 code: variables.code ?? accessCode.code,

--- a/src/lib/seam/components/EditAccessCodeForm/EditAccessCodeForm.tsx
+++ b/src/lib/seam/components/EditAccessCodeForm/EditAccessCodeForm.tsx
@@ -141,6 +141,7 @@ function useSubmitEditAccessCode(
       {
         access_code_id: accessCode.access_code_id,
         name,
+        code,
         type: 'ongoing',
         device_id: device.device_id,
       },


### PR DESCRIPTION
closes #491

We were previously re-fetching the AccessCode immediately after a successful update response. This would occasionally happen before the Action Attempt has been processed, resulting in stale data back.

The fix here is to just optimistically update the UI, and assume the action will eventually be successful. 

If the user refreshes, and the action hasn't been processed, they would still see the old (stale) data. Although this isn't ideal, it's still better than the current situation, which doesn't provide any feedback that the data has changed at all.

### Notable things

- Also fixed a bug where updating an `ongoing` Access Code's code wouldn't have worked.

### Screenshots

#### Updating code from table


https://github.com/seamapi/react/assets/11449462/23191a80-9eec-4ab1-9915-2dce1013822f



#### Updating code from details


https://github.com/seamapi/react/assets/11449462/ec74b569-f3fa-4812-b035-9c81a0c8f07c

