### PR TITLE
Add hooks for new devicedb

### DIFF
--- a/.storybook/devicedb-seed.json
+++ b/.storybook/devicedb-seed.json
@@ -366,9 +366,7 @@
       "is_device_supported": false,
       "product_url": "https://level.co/products/lock",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -510,9 +508,7 @@
       "is_device_supported": false,
       "product_url": "https://us.eufy.com/collections/smart-lock/products/t8502111",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -558,9 +554,7 @@
       "is_device_supported": false,
       "product_url": "https://us.eufy.com/products/e85301y1?ref=navimenu_3_img",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -606,9 +600,7 @@
       "is_device_supported": false,
       "product_url": "https://us.eufy.com/collections/smart-lock/products/t8504121",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -654,9 +646,7 @@
       "is_device_supported": false,
       "product_url": "https://us.eufy.com/products/t8520?ref=navimenu_3_img",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -751,9 +741,7 @@
       "is_device_supported": false,
       "product_url": "https://us.eufy.com/collections/smart-lock/products/t8503111",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -799,9 +787,7 @@
       "is_device_supported": false,
       "product_url": "https://us.eufy.com/collections/smart-lock/products/t8510",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -879,9 +865,7 @@
       "is_device_supported": false,
       "product_url": "https://www.wyze.com/products/wyze-lock?variant=40925869899938",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -932,9 +916,7 @@
       "is_device_supported": false,
       "product_url": "https://www.wyze.com/products/wyze-lock-bolt",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -990,10 +972,7 @@
       "is_device_supported": false,
       "product_url": "https://www.aqara.com/en/product/smart-lock-u100",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery",
-        "hardwired"
-      ],
+      "power_sources": ["battery", "hardwired"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1044,10 +1023,7 @@
       "is_device_supported": false,
       "product_url": "https://www.aqara.com/en/product/smart-door-lock-d100-zigbee",
       "main_connection_type": "zigbee",
-      "power_sources": [
-        "battery",
-        "hardwired"
-      ],
+      "power_sources": ["battery", "hardwired"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -1109,10 +1085,7 @@
       "is_device_supported": false,
       "product_url": "https://www.aqara.com/en/product/smart-door-lock-n100-zigbee",
       "main_connection_type": "zigbee",
-      "power_sources": [
-        "battery",
-        "hardwired"
-      ],
+      "power_sources": ["battery", "hardwired"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -1174,10 +1147,7 @@
       "is_device_supported": false,
       "product_url": "https://www.aqara.com/en/product/smart-door-lock-a100-zigbee",
       "main_connection_type": "zigbee",
-      "power_sources": [
-        "battery",
-        "hardwired"
-      ],
+      "power_sources": ["battery", "hardwired"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -1229,9 +1199,7 @@
       "is_device_supported": false,
       "product_url": "https://alfredinc.com/collections/products/products/ml2",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1277,9 +1245,7 @@
       "is_device_supported": false,
       "product_url": "https://alfredinc.com/collections/products/products/db1-with-bluetooth-and-z-wave?variant=38032721412289",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1326,9 +1292,7 @@
       "is_device_supported": false,
       "product_url": "https://alfredinc.com/collections/products/products/db1-with-bluetooth?variant=38032698179777",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1375,9 +1339,7 @@
       "is_device_supported": false,
       "product_url": "https://alfredinc.com/collections/products/products/db2b?variant=35219989168290",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1512,9 +1474,7 @@
       "is_device_supported": false,
       "product_url": "https://alfredinc.com/collections/products/products/db1-with-bluetooth?variant=38032698147009",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1561,9 +1521,7 @@
       "is_device_supported": false,
       "product_url": "https://alfredinc.com/collections/products/products/db1-with-bluetooth-and-z-wave?variant=38032721445057",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1610,9 +1568,7 @@
       "is_device_supported": false,
       "product_url": "https://alfredinc.com/collections/products/products/db2",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1707,10 +1663,7 @@
       "is_device_supported": false,
       "product_url": "https://www.latch.com/m-series",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery",
-        "wireless"
-      ],
+      "power_sources": ["battery", "wireless"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -1768,10 +1721,7 @@
       "is_device_supported": false,
       "product_url": "https://www.latch.com/egenius-powered-by-latch",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery",
-        "wireless"
-      ],
+      "power_sources": ["battery", "wireless"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1812,10 +1762,7 @@
       "is_device_supported": false,
       "product_url": "https://www.latch.com/c2",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery",
-        "wireless"
-      ],
+      "power_sources": ["battery", "wireless"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -1873,9 +1820,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/au/en/products/smart-products/unity-entrance-series/yale-unity-entrance-lock",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -1917,9 +1862,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/au/en/products/smart-products/unity-entrance-series/yale-unity-entrance-lock-fire-rated",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -1971,9 +1914,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/in/en/products/smart-products/digital-door-locks/connected-/ydm-3115",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -2025,9 +1966,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/ph/en/products/yale-smart-locks/yale-mortise-locks/ymi70a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -2079,9 +2018,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/in/en/products/smart-products/digital-door-locks/connected-/ydr41-vertibolt-lock",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lockbox",
@@ -2133,9 +2070,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lever-keypad-with-wi-fi?variant=41356967608452",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -2215,9 +2150,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/ae/en/products/smart-door-locks/smart-mortice-locks/smart-door-lock-ydm4109a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -2323,9 +2256,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/my/en/products/smart-lock/yale-access-app-smart-lock/ydf40a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -2377,9 +2308,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/metal-gate-smart-locks/ydr50ga",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lockbox",
@@ -2431,9 +2360,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lock-touchscreen-with-z-wave-plus?variant=39341912326276",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -2546,9 +2473,7 @@
       "is_device_supported": true,
       "product_url": "",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -2655,9 +2580,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/my/en/products/smart-lock/yale-access-app-smart-lock/ymf40a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -2709,9 +2632,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/au/en/products/smart-products/unity-entrance-series/yale-unity-screen-door-lock",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -2762,9 +2683,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/collections/smart-locks/products/yale-assure-lever-keypad-with-wi-fi-and-bluetooth?variant=39341913735300",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -2821,9 +2740,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/id/en/products/smart-lock/yale-access-app-smart-lock/ymf30a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -2875,9 +2792,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/ae/en/products/smart-door-locks/smart-mortice-locks/smart-door-lock-ydm3109a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -2929,9 +2844,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/wooden-door-smart-locks/yale-access-app-smart-locks/ydd424a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -2983,9 +2896,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/hk/en/products/digital-door-lock/yale-access-app-smart-lock/smart-lock-pro",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -3027,9 +2938,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lock-keypad-with-wi-fi-and-bluetooth?variant=39341913800836",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -3109,9 +3018,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/in/en/products/smart-products/digital-door-locks/connected-/ydr414-rim-lock",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -3173,9 +3080,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/pages/yale-assure-lock-2",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -3293,9 +3198,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/hk/en/products/digital-door-lock/yale-link-app-smart-lock/ydm7216",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -3347,9 +3250,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/pages/yale-assure-lock-2",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -3484,9 +3385,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lock-keypad-with-z-wave-plus?variant=39341912785028",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -3581,9 +3480,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/metal-gate-smart-locks/ydr30ga",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lockbox",
@@ -3635,9 +3532,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lock-sl-with-z-wave-plus?variant=39341911834756",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -3760,9 +3655,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/ph/en/products/yale-smart-locks/yale-smart-rim-locks/j20a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lockbox",
@@ -3824,9 +3717,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/ph/en/products/yale-smart-locks/yale-mortise-locks/ydm7116a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -3883,9 +3774,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/se/sv/products/smart-locks/yale-doorman-l3",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -3993,9 +3882,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/hk/en/products/digital-door-lock/finger-print-digital-door-lock/ydm4115",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -4073,9 +3960,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lock-2-key-free-keypad-with-bluetooth?variant=41535299321988",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -4183,9 +4068,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/wooden-door-smart-locks/yale-access-app-smart-locks/ydd724a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -4237,9 +4120,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/ph/en/products/yale-smart-locks/yale-mortise-locks/ydm7220",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -4296,9 +4177,7 @@
       "is_device_supported": true,
       "product_url": "https://yalehome.co.uk/linus-smart-door-lock/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -4368,9 +4247,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lever-touchscreen-with-wi-fi?variant=41415042760836",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -4422,9 +4299,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/my/en/products/smart-lock/yale-access-app-smart-lock/ydg413a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lockbox",
@@ -4486,9 +4361,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lock-2-touchscreen-with-bluetooth?variant=41535298863236",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -4616,9 +4489,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/collections/smart-locks/products/yale-assure-lever-touchscreen-with-wi-fi-and-bluetooth?variant=39341913440388",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -4708,9 +4579,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/collections/patio-door-locks/products/assure-lock-for-andersen-patio-doors-standalone?variant=39337803350148",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -4803,9 +4672,7 @@
       "is_device_supported": true,
       "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/wooden-door-smart-locks/yale-access-app-smart-locks/ydr3110a",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -4857,9 +4724,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/pages/yale-assure-lock-2",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -4964,9 +4829,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/pages/yale-assure-lock-2",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -5084,9 +4947,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/products/yale-assure-lock-touchscreen-with-wi-fi-and-bluetooth?variant=39341913112708",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -5199,9 +5060,7 @@
       "is_device_supported": true,
       "product_url": "https://shopyalehome.com/collections/smart-locks/products/yale-assure-lever-touchscreen-with-wi-fi-and-bluetooth?variant=39341913473156",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -5276,9 +5135,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/smart-locks/connected-keypads.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -5325,9 +5182,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/BE369NXCAMFFF.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -5379,9 +5234,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/FBE469NXCAMFFFACC.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -5549,9 +5402,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/smart-locks/encode-lever.html",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -5688,9 +5539,7 @@
       "is_device_supported": false,
       "product_url": "https://www.schlage.com/en/home/products/BE479CENFFF.html",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -5846,9 +5695,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/FE469NXCAMFFFACC.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -6016,9 +5863,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/BE469ZPCENFFF.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -6217,9 +6062,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/BE469ZPCAMFFF.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -6443,9 +6286,7 @@
       "is_device_supported": false,
       "product_url": "https://www.schlage.com/en/home/products/BE479CAMFFF.html",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -6601,9 +6442,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/BE499WBCENFFF.html",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -6799,9 +6638,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/BE489WBCAMFFF.html",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -7179,9 +7016,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/BE469NXCAMFFF.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -7445,9 +7280,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/BE369NXCAMFFF.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -7527,9 +7360,7 @@
       "is_device_supported": true,
       "product_url": "https://www.schlage.com/en/home/products/FBE469NXCENFFFACC.html",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -7629,9 +7460,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/919-premis-contemporary-smart-lock?variant=919cnt-premis-15",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -7709,9 +7538,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/obsidian-keywayless-electronic-touchscreen-smart-deadbolt-with-z-wave-technology?variant=954-obn-zw-15",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -7786,9 +7613,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/home-connect-620-contemporary-keypad-connected-smart-lock-with-z-wave-technology?variant=hc620-cnt-zw700-15-smt-rcal-rcs-cp",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -7969,9 +7794,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/910-smartcode-traditional-electronic-deadbolt-with-z-wave-technology",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -8064,9 +7887,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/halo-touch-traditional-fingerprint-wi-fi-enabled-smart-lock?variant=959-trl-fprt-wifi-15",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -8166,9 +7987,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/halo-keypad-wi-fi-enabled-smart-lock?variant=938-wifi-kypd-15",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -8273,9 +8092,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/912-smartcode-electronic-tustin-lever-with-z-wave-technology?variant=912tnl-trl-zw-l03",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -8383,9 +8200,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/aura-bluetooth-enabled-smart-lock?variant=942-ble-db-15",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -8533,9 +8348,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/916-smartcode-contemporary-electronic-deadbolt-with-z-wave-technology?variant=916cnt-zw500-514",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -8711,9 +8524,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/home-connect-620-traditional-keypad-connected-smart-lock-with-z-wave-technology?variant=hc620-trl-zw700-11p-smt-rcal-rcs-cp",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -8856,9 +8667,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/halo-touchscreen-wi-fi-enabled-smart-lock?variant=939-wifi-tscr-11p",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -9039,9 +8848,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/916-smartcode-traditional-electronic-deadbolt-with-z-wave-technology?variant=916trl-zw-11p",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -9141,9 +8948,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/halo-touch-contemporary-fingerprint-wi-fi-enabled-smart-lock?variant=959-cnt-fprt-wifi-15",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -9258,9 +9063,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/888-smartcode-electronic-deadbolt-with-z-wave-technology?variant=888-zw-15",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -9383,9 +9186,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/910-smartcode-contemporary-electronic-deadbolt-with-z-wave-technology?variant=910-cnt-zw-15",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -9501,9 +9302,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/914-smartcode-contemporary-electronic-deadbolt-with-z-wave-technology?variant=914cnt-zw500-26",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -9689,9 +9488,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/914-smartcode-traditional-electronic-deadbolt-with-z-wave-technology?variant=914trl-zw-11p",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -9804,9 +9601,7 @@
       "is_device_supported": true,
       "product_url": "https://www.kwikset.com/products/detail/919-premis-traditional-smart-lock?variant=919trl-premis-15",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -9906,9 +9701,7 @@
       "is_device_supported": true,
       "product_url": "https://www.brivo.com/products/smart-locks/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -9937,9 +9730,7 @@
       "is_device_supported": true,
       "product_url": "https://www.brivo.com/products/smart-locks/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -9968,9 +9759,7 @@
       "is_device_supported": true,
       "product_url": "https://www.iglooworks.co/hardware/padlock-e",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "padlock",
@@ -10042,9 +9831,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/mortise-2-plus",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -10101,9 +9888,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/rim-lock-wooden-doors",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -10155,9 +9940,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/push-pull-mortise",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -10209,9 +9992,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/rim-lock",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -10268,9 +10049,7 @@
       "is_device_supported": true,
       "product_url": "https://www.iglooworks.co/hardware/iot-deadbolt",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -10326,9 +10105,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/lever-mortise",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -10370,10 +10147,7 @@
       "is_device_supported": true,
       "product_url": "https://www.iglooworks.co/hardware/swing-handle",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery",
-        "hardwired"
-      ],
+      "power_sources": ["battery", "hardwired"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "locker",
@@ -10440,9 +10214,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/padlock",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "padlock",
@@ -10489,9 +10261,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/mortise-2",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -10543,9 +10313,7 @@
       "is_device_supported": true,
       "product_url": "https://www.iglooworks.co/hardware/keybox-3e",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lockbox",
@@ -10617,9 +10385,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/deadbolt-2s-mg",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -10676,9 +10442,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/retrofit-lock",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -10725,9 +10489,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/keybox-3",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lockbox",
@@ -10789,9 +10551,7 @@
       "is_device_supported": true,
       "product_url": "https://www.iglooworks.co/hardware/deadbolt-2e",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -10848,9 +10608,7 @@
       "is_device_supported": true,
       "product_url": "https://www.igloohome.co/products/gate-lock",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -10930,9 +10688,7 @@
       "is_device_supported": false,
       "product_url": "https://akiles.app/en/products/smart-lock-system-room-lock",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -10983,9 +10739,7 @@
       "is_device_supported": false,
       "product_url": "https://akiles.app/en/products/smart-lock-system-cylinder",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -11249,9 +11003,7 @@
       "is_device_supported": true,
       "product_url": "",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -11297,9 +11049,7 @@
       "is_device_supported": false,
       "product_url": "https://www.4suiteshq.com/hotel-locks/",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -11340,9 +11090,7 @@
       "is_device_supported": false,
       "product_url": "https://www.4suiteshq.com/readers/",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "hardwired"
-      ],
+      "power_sources": ["hardwired"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "unknown",
@@ -11383,9 +11131,7 @@
       "is_device_supported": false,
       "product_url": "https://www.4suiteshq.com/hotel-locks/",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -11426,9 +11172,7 @@
       "is_device_supported": false,
       "product_url": "https://us.switch-bot.com/collections/all/products/switchbot-lock?variant=43991839932649",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -11506,9 +11250,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/228sl/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -11596,9 +11338,7 @@
       "is_device_supported": true,
       "product_url": "https://lockly.com/products/lockly-flex-touch-deadbolt",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -11645,9 +11385,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/228sw/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -11745,9 +11483,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/679l/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -11830,9 +11566,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/678w/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -11893,9 +11627,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/7a/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -11949,9 +11681,7 @@
       "is_device_supported": true,
       "product_url": "https://lockly.com/products/lockly-secure-pro?variant=19786767368251",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -12074,9 +11804,7 @@
       "is_device_supported": true,
       "product_url": "https://lockly.com/products/lockly-secure-advanced-smart-lock-door?variant=21228386549819",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -12164,9 +11892,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/238l/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -12200,9 +11926,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/698d/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -12270,9 +11994,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/728fz/",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -12360,9 +12082,7 @@
       "is_device_supported": true,
       "product_url": "https://lockly.com/collections/door-lock/products/lockly-vision-doorbell-camera-smart-lock",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -12480,9 +12200,7 @@
       "is_device_supported": true,
       "product_url": "https://lockly.com/products/lockly-secure-pro?variant=19786767368251",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -12615,9 +12333,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/679d/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lever",
@@ -12700,9 +12416,7 @@
       "is_device_supported": true,
       "product_url": "https://locklypro.com/728z/",
       "main_connection_type": "unknown",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -12805,9 +12519,7 @@
       "is_device_supported": true,
       "product_url": "https://august.com/products/august-wifi-smart-lock?view=wifi-smart-lock-2",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -12887,9 +12599,7 @@
       "is_device_supported": true,
       "product_url": "",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -12969,9 +12679,7 @@
       "is_device_supported": true,
       "product_url": "https://august.com/products/august-wifi-smart-lock",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -13041,9 +12749,7 @@
       "is_device_supported": true,
       "product_url": "",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -13126,9 +12832,7 @@
       "is_device_supported": true,
       "product_url": "https://august.com/products/august-smart-lock-3rd-generation",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -13251,9 +12955,7 @@
       "is_device_supported": true,
       "product_url": "",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -13338,9 +13040,7 @@
       "is_device_supported": true,
       "product_url": "",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -13435,9 +13135,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en-in/products/xs4-original-plus-eu/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -13478,9 +13176,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/aelement-fusion-eu-din/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -13521,9 +13217,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-deadbolt-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -13569,9 +13263,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-one-din/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -13622,9 +13314,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en-us/products/electronic-locks/xs4-original-ansi/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -13665,9 +13355,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-uk-oval-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -13730,9 +13418,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en-in/products/xs4-original-keypad-eu/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -13773,9 +13459,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-mini-finnish/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -13843,9 +13527,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-mini-scandinavian/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -13913,9 +13595,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/aelement-fusion-ansi/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -13956,9 +13636,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-australian-oval-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -14021,9 +13699,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-swing-handle-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -14069,9 +13745,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-mini-european-din/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -14139,9 +13813,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-original-wide-plus-eu/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -14182,9 +13854,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-original-plus-scandinavian/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -14225,9 +13895,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/electronic-locks/xs4-one/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -14273,9 +13941,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neoxx-padlock-g4/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "padlock",
@@ -14326,9 +13992,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-european-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -14391,9 +14055,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-original-plus-wide-scandinavian/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -14434,9 +14096,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en-in/products/xs4-locker-locks/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "locker",
@@ -14494,9 +14154,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-rim-us-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -14559,9 +14217,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-original-plus-din_satin-stainless-steel/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -14617,9 +14273,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/design-xs-ansi-keypad-wall-reader/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "hardwired"
-      ],
+      "power_sources": ["hardwired"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "lockbox",
@@ -14689,9 +14343,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-swiss-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -14754,9 +14406,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-cam-lock-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -14819,9 +14469,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/electronic-cylinders/neo-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -14884,9 +14532,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-mini-australia/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -14954,9 +14600,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-scandinavian-oval-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -15024,9 +14668,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-one-deadlatch/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -15072,9 +14714,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-original-keypad-scandinavian/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -15115,9 +14755,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-glass-door-din/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -15158,9 +14796,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-scandinavian-security-cylinder",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -15223,9 +14859,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-mortise-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -15288,9 +14922,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neo-rim-uk-cylinder/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "cylinder",
@@ -15353,9 +14985,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/xs4-mini-ansi/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -15413,9 +15043,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en/products/salto-neoxx-padlock-g3/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "padlock",
@@ -15461,9 +15089,7 @@
       "is_device_supported": true,
       "product_url": "https://saltosystems.com/en-in/products/xs4-original-keypad-ansi/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "mortise",
@@ -15504,9 +15130,7 @@
       "is_device_supported": true,
       "product_url": "https://www.amazon.ae/NUKi-Home-Solutions-Smart-220113/dp/B07F1PGYBW",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -15552,9 +15176,7 @@
       "is_device_supported": true,
       "product_url": "https://nuki.io/en/smart-lock-pro/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",
@@ -15622,9 +15244,7 @@
       "is_device_supported": true,
       "product_url": "https://nuki.io/en/smart-lock/",
       "main_connection_type": "wifi",
-      "power_sources": [
-        "battery"
-      ],
+      "power_sources": ["battery"],
       "main_category": "smartlock",
       "physical_properties": {
         "lock_type": "deadbolt",

--- a/.storybook/devicedb-seed.json
+++ b/.storybook/devicedb-seed.json
@@ -1,0 +1,15669 @@
+{
+  "manufacturers": [
+    {
+      "manufacturer_id": "315a3ef9-ab84-4eab-8abb-b5c4187125d6",
+      "display_name": "",
+      "integration": "unsupported",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "3713359d-3d8e-43b4-bc2b-03fbe80e727d",
+      "display_name": "2N",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "1f47b69f-1c4c-469b-b9e2-2fd1fb287de8",
+      "display_name": "4SUITES",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "2fc1f5de-8606-4ace-af64-9851ceef2712",
+      "display_name": "Akuvox",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "4351e244-9f6c-469d-ae5a-21b2e88806f2",
+      "display_name": "Alfred",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "b1d4b11f-c068-4e00-b7ac-e62792c92e01",
+      "display_name": "American Standard",
+      "integration": "unsupported",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "cdfc35c1-9f51-40f6-a9d3-fab99db8e08a",
+      "display_name": "Aprilaire",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "1d2f1d14-c3ce-4605-8817-98c64a69d07c",
+      "display_name": "Aqara",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "cfe546ca-7a99-48e0-a665-4304dca85b4e",
+      "display_name": "August",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "1d4b7455-0116-4f05-be61-d1e024ecb942",
+      "display_name": "Avigilon Alta",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "2abbfb06-d081-419a-ab40-25d8ac10f88a",
+      "display_name": "Bosch",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "edcd4e38-a066-4502-be95-364fc54787ae",
+      "display_name": "Brivo",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "08171d9e-1a46-4b66-8e5d-c89c6022dbf5",
+      "display_name": "ButterflyMX",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "a076754f-eea6-4436-9ae6-df729f1b6513",
+      "display_name": "Comelit",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "5bcb7f66-21ed-47dd-b4c9-ae7c78712a39",
+      "display_name": "ControlByWeb",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "9143379f-2742-4381-a183-afb58910df7f",
+      "display_name": "DoorBird",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "04cdcb39-5d02-4368-97aa-1e07420e5f38",
+      "display_name": "DoorKing",
+      "integration": "beta",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "ac9cecfc-5784-4e4a-ad49-6a1a7b1c1748",
+      "display_name": "Eufy",
+      "integration": "unsupported",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "8789988c-a5b7-4840-8672-949022394a52",
+      "display_name": "Genie",
+      "integration": "beta",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "d5f9ebe3-89bc-4030-bcde-d1adfd18560a",
+      "display_name": "Honeywell",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "246ef719-d7b2-4214-8dd8-d74e2e7fff36",
+      "display_name": "Hubitat",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "display_name": "Kwikset",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "780f2160-c664-4f8e-a9df-cb5570cb00b3",
+      "display_name": "LUX",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "01891d08-0aab-47ff-a506-9c6a130e17c6",
+      "display_name": "Latch",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "52e50228-4cdb-4aad-b83e-aab6e746cbfe",
+      "display_name": "Level",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "a5775454-124d-4ccd-8e8c-94f6fb0b42dd",
+      "display_name": "Linear",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "display_name": "Lockly",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "eff445ba-064c-4894-b4d5-0751e98da5d5",
+      "display_name": "Minut",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "ff1cb188-9566-4627-888a-07ceb8cb444f",
+      "display_name": "Nest",
+      "integration": "beta",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "34a8fd85-9ea4-4175-b6db-491e7457bcab",
+      "display_name": "NoiseAware",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "ed3ef2c0-5e2b-452a-ab9d-eb3aa9a9eada",
+      "display_name": "Nuki",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "99f8a4a7-65ba-4a41-bebd-f6aed5eed836",
+      "display_name": "RBH",
+      "integration": "beta",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "fd52b87d-e53a-478c-bf10-7e0ac4b466a1",
+      "display_name": "Roomonitor",
+      "integration": "unsupported",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "display_name": "Salto",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "display_name": "Schlage",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "d87da36e-b374-4615-8471-e66f3ef3d058",
+      "display_name": "Sensibo",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "3574928e-3f09-4a38-ab90-1c72a9e04f89",
+      "display_name": "Sinopé",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "f7c9c576-7db5-47fe-a65e-bef518ff4308",
+      "display_name": "SmartThings",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "136ee03e-7b5c-4e1f-9c75-575499bff32c",
+      "display_name": "SwitchBot",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "5d273929-b5a2-49f4-af6c-146920dc90c9",
+      "display_name": "TTLock",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "66b21885-a833-4c0f-9464-798d655ca52c",
+      "display_name": "Tedee",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "581f40fc-7ce8-4e6a-829d-08becb012885",
+      "display_name": "Trane",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "fe6fad54-43b9-40d6-b619-7dd769603c7d",
+      "display_name": "Venstar",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "fda20164-fea3-420a-86c9-764f917e5713",
+      "display_name": "Viking",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "16dae1f4-8b2a-485a-bb80-cc9262a5a053",
+      "display_name": "Wyze",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "display_name": "Yale",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "8a4689c5-9f27-4f69-8acb-44cbc74ee258",
+      "display_name": "akiles",
+      "integration": "planned",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "983d1ec8-8e4f-4930-a3df-2fa45370f7f9",
+      "display_name": "ecobee",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "display_name": "igloohome",
+      "integration": "stable",
+      "is_connect_webview_supported": true,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "9b4d3f78-8896-41cc-aae8-6b6b4943585b",
+      "display_name": "iglooworks",
+      "integration": "unsupported",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    },
+    {
+      "manufacturer_id": "5a605908-b332-4343-ab45-c5e0925a5f68",
+      "display_name": "third-party",
+      "integration": "unsupported",
+      "is_connect_webview_supported": false,
+      "requires_seam_support_to_add_account": false
+    }
+  ],
+  "device_models": [
+    {
+      "device_model_id": "8bac86d7-23f5-4e04-ad03-7b91fc9e778b",
+      "display_name": "Lock",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://level.co/products/lock",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "52e50228-4cdb-4aad-b83e-aab6e746cbfe",
+      "aesthetic_variants": [
+        {
+          "slug": "polished_brass",
+          "display_name": "Polished Brass",
+          "primary_color_hex": "#b3b3b3",
+          "images": [
+            {
+              "image_id": "06ed0acf-aac0-409f-a3e4-a9acad5673b1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "bc7d14cc-7139-433e-849f-4cd98d8655dd",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#a49b94",
+          "front_image": {
+            "image_id": "86f7732e-4c26-4e0e-8289-c4a3755cbb81",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "7c079c7d-f74d-4e7c-bbfd-1d608bb9a768",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "86f7732e-4c26-4e0e-8289-c4a3755cbb81",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7c079c7d-f74d-4e7c-bbfd-1d608bb9a768",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0fd7de41-9745-44c0-9948-033b59fd4e40",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a740f6b6-b17b-4671-800f-8c6c1e622538",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b2680a18-34e6-4434-80a5-dab8017d3449",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#16171c",
+          "front_image": {
+            "image_id": "0568979e-d0a2-44a8-a93a-1311b022bf9c",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4c0ff4b9-c21d-4695-acbc-d71a9bcf89ad",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "0568979e-d0a2-44a8-a93a-1311b022bf9c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4c0ff4b9-c21d-4695-acbc-d71a9bcf89ad",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e5737b3f-65ef-4c9c-8c94-8a428a62a507",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3b0c42a4-4100-4f64-8615-fa63a8923311",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "495e166e-2d03-4378-b9d7-b8b4349c7ba1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_chrome",
+          "display_name": "Satin Chrome",
+          "primary_color_hex": "#b3b3b3",
+          "images": [
+            {
+              "image_id": "63ee421e-5e10-4a73-9238-1047398fcd87",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5cb7ec30-3d03-4fcc-a7db-e03b67d889bd",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "295c372c-7175-4ebc-ac4a-beb6f5c3bd3a",
+      "display_name": "Wi-Fi Smart Lock E110",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://us.eufy.com/collections/smart-lock/products/t8502111",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ac9cecfc-5784-4e4a-ad49-6a1a7b1c1748",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#030303",
+          "front_image": {
+            "image_id": "3cf10188-f81f-4dfe-a0c5-b27aef45e863",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3cf10188-f81f-4dfe-a0c5-b27aef45e863",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7f7f500d-ac9b-4d3b-8ebb-243fdd534bf6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "600862e2-47f2-40c2-9acc-d0cb1072b8ff",
+      "display_name": "Video Smart Lock",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://us.eufy.com/products/e85301y1?ref=navimenu_3_img",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": true
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ac9cecfc-5784-4e4a-ad49-6a1a7b1c1748",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#383838",
+          "front_image": {
+            "image_id": "3899a010-d3cc-4eef-95ac-1799be2fc8c8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3899a010-d3cc-4eef-95ac-1799be2fc8c8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0bf0d453-0726-44bb-bfe3-dfb345edc9e6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "c2725703-345c-4f4e-9881-f56e3a74de41",
+      "display_name": "Smart Lock E260 Retrofit",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://us.eufy.com/collections/smart-lock/products/t8504121",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ac9cecfc-5784-4e4a-ad49-6a1a7b1c1748",
+      "aesthetic_variants": [
+        {
+          "slug": "nickel",
+          "display_name": "Nickel",
+          "primary_color_hex": "#a0a3ab",
+          "back_image": {
+            "image_id": "dfb3106c-e340-47fa-a748-1df6d98bfbc5",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dfb3106c-e340-47fa-a748-1df6d98bfbc5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7f614d5f-040b-4cb7-9ba3-43ada1ff30b4",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "05fde5d2-3bb2-4214-9dd5-50a95a759fda",
+      "display_name": "Smart Lock Touch and Wi-Fi",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://us.eufy.com/products/t8520?ref=navimenu_3_img",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ac9cecfc-5784-4e4a-ad49-6a1a7b1c1748",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#0a0a0a",
+          "front_image": {
+            "image_id": "171f5f89-2a6b-4e50-9e7f-e161d1cf7b53",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "171f5f89-2a6b-4e50-9e7f-e161d1cf7b53",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0b10df01-10ee-47f6-b2a8-6cb6b7a7d326",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#c5c4c9",
+          "front_image": {
+            "image_id": "c31aea42-b346-4c01-9c66-860307cbcbaf",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c31aea42-b346-4c01-9c66-860307cbcbaf",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5476cf4e-e0da-4579-b611-30c74ff28485",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f5fb4079-34f1-4948-bc8d-99a98f667832",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "nickel",
+          "display_name": "Nickel",
+          "primary_color_hex": "#d8d1c3",
+          "front_image": {
+            "image_id": "5bd2226d-92b1-45db-ab8f-aa68ed4c5ed8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5bd2226d-92b1-45db-ab8f-aa68ed4c5ed8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1691b317-73cd-4b77-b2c7-371d724e0486",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "9a27858e-6dba-4bb2-8b69-730a60c5aa6a",
+      "display_name": "Smart Lock R10 Retrofit",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://us.eufy.com/collections/smart-lock/products/t8503111",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ac9cecfc-5784-4e4a-ad49-6a1a7b1c1748",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "74f71a2d-b470-4a85-b79f-9c35a7f73905",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "74f71a2d-b470-4a85-b79f-9c35a7f73905",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "eec5c7e6-f4f0-41f5-acb9-4361609fab48",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "5ab2d1a7-6d3c-4ac7-aa3c-de43b17234ad",
+      "display_name": "Smart Lock Touch",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://us.eufy.com/collections/smart-lock/products/t8510",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ac9cecfc-5784-4e4a-ad49-6a1a7b1c1748",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#0d0d0d",
+          "front_image": {
+            "image_id": "7f73ec01-532c-42de-8159-e57e38f26788",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e0e4621e-667b-472f-9758-7bf820e49875",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7f73ec01-532c-42de-8159-e57e38f26788",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e0e4621e-667b-472f-9758-7bf820e49875",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "nickel",
+          "display_name": "Nickel",
+          "primary_color_hex": "#c7bead",
+          "front_image": {
+            "image_id": "c59e9112-6d99-4d0f-b5bc-500908223368",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "49121980-5df5-494f-b54e-515e73af8b0f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c59e9112-6d99-4d0f-b5bc-500908223368",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "49121980-5df5-494f-b54e-515e73af8b0f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "553f11e3-3b67-4065-a95c-2b1320aacafb",
+      "display_name": "Lock",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.wyze.com/products/wyze-lock?variant=40925869899938",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "16dae1f4-8b2a-485a-bb80-cc9262a5a053",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#d2d4d8",
+          "front_image": {
+            "image_id": "0f0cece6-0f05-484a-becb-92a161a6e35b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "0f0cece6-0f05-484a-becb-92a161a6e35b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "43f1752c-5b2c-4264-80ce-d8d645bb3cce",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "aa4bc5d6-0a98-4556-9af9-2dada63b522d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "701e0df7-d5d1-471e-b04e-8f7f5505814c",
+      "display_name": "Lock Bolt",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.wyze.com/products/wyze-lock-bolt",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "16dae1f4-8b2a-485a-bb80-cc9262a5a053",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "images": []
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#343434",
+          "front_image": {
+            "image_id": "7c308639-ff01-4ef2-b057-28f8d4217c94",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "07b807f8-276d-4226-99e7-e5ca1642b5a5",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7c308639-ff01-4ef2-b057-28f8d4217c94",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "07b807f8-276d-4226-99e7-e5ca1642b5a5",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "148a97bd-7aaf-4c7d-aa4f-5534482bcbc3",
+      "display_name": "Smart Lock U100",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.aqara.com/en/product/smart-lock-u100",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery",
+        "hardwired"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": true
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "1d2f1d14-c3ce-4605-8817-98c64a69d07c",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#a3a4a5",
+          "front_image": {
+            "image_id": "8a892ede-3b87-48a4-afd7-05e0dd7febc8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "376a20d5-5d34-4d33-b4dd-5e1cfd67bb1e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8a892ede-3b87-48a4-afd7-05e0dd7febc8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "376a20d5-5d34-4d33-b4dd-5e1cfd67bb1e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "d320021c-878f-43c3-96b6-dec4f57ebc70",
+      "display_name": "Smart Door Lock D100 Zigbee",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.aqara.com/en/product/smart-door-lock-d100-zigbee",
+      "main_connection_type": "zigbee",
+      "power_sources": [
+        "battery",
+        "hardwired"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "1d2f1d14-c3ce-4605-8817-98c64a69d07c",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#030303",
+          "manufacturer_sku": "ZNMS20LM",
+          "front_image": {
+            "image_id": "b4501beb-1639-4be1-9dc4-01a64605504b",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b8fea2d3-d0dd-40b1-86dc-7af617a5080b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b4501beb-1639-4be1-9dc4-01a64605504b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e2118de2-1314-4f94-b118-d5608358c402",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "20c2514d-0c3c-4dd4-8cff-f76fee9903e2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b8fea2d3-d0dd-40b1-86dc-7af617a5080b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6ba8c9f6-b218-45c8-b829-33bd6d8d6932",
+      "display_name": "Smart Door Lock N100 Zigbee",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.aqara.com/en/product/smart-door-lock-n100-zigbee",
+      "main_connection_type": "zigbee",
+      "power_sources": [
+        "battery",
+        "hardwired"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "1d2f1d14-c3ce-4605-8817-98c64a69d07c",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#151515",
+          "manufacturer_sku": "ZNMS16LM",
+          "front_image": {
+            "image_id": "651024e7-0cb0-4ffe-a9b5-b42c57bf88eb",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "30bff25c-5c71-4a34-bde8-c1e223b6c573",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "651024e7-0cb0-4ffe-a9b5-b42c57bf88eb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d13ec765-a09b-4950-bbcb-570a8a138f84",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "30bff25c-5c71-4a34-bde8-c1e223b6c573",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2ed89b33-af24-4299-b8e2-285a5eb3eefe",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "a70f56d4-28fb-4aca-b7d7-83cfeab7db22",
+      "display_name": "Smart Door Lock A100 Zigbee",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.aqara.com/en/product/smart-door-lock-a100-zigbee",
+      "main_connection_type": "zigbee",
+      "power_sources": [
+        "battery",
+        "hardwired"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "1d2f1d14-c3ce-4605-8817-98c64a69d07c",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#303235",
+          "manufacturer_sku": "ZNMS02ES",
+          "front_image": {
+            "image_id": "382b8065-5527-4223-a5a3-193bd49fe95e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "74ad8da6-be95-4051-84eb-5a419e0a64a5",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "382b8065-5527-4223-a5a3-193bd49fe95e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "74ad8da6-be95-4051-84eb-5a419e0a64a5",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8df3dc5d-d960-415a-9616-7f088db66b37",
+      "display_name": "ML2",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://alfredinc.com/collections/products/products/ml2",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "4351e244-9f6c-469d-ae5a-21b2e88806f2",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#1c1c1e",
+          "front_image": {
+            "image_id": "7bc140e6-46ca-4da9-bb68-c4f4fadead9b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7bc140e6-46ca-4da9-bb68-c4f4fadead9b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3fd75e23-8031-49d9-9e98-e14d32893c7a",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "15e39efe-1aef-433b-b5f2-86f33082a94f",
+      "display_name": "DB1 with Bluetooth and Z-Wave with Key Override",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://alfredinc.com/collections/products/products/db1-with-bluetooth-and-z-wave?variant=38032721412289",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "4351e244-9f6c-469d-ae5a-21b2e88806f2",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#242424",
+          "manufacturer_sku": "DB1-B",
+          "front_image": {
+            "image_id": "dadd3b26-ac7b-4489-8bc8-6b3ae8d47ede",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dadd3b26-ac7b-4489-8bc8-6b3ae8d47ede",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d97e5f51-a8a8-4a28-bd8b-58e7ea7978ad",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "d2bf8458-855f-4952-81ae-efe988c2ee8f",
+      "display_name": "DB1 with Bluetooth with Key Override",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://alfredinc.com/collections/products/products/db1-with-bluetooth?variant=38032698179777",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "4351e244-9f6c-469d-ae5a-21b2e88806f2",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#242424",
+          "manufacturer_sku": "DB1-A",
+          "front_image": {
+            "image_id": "dadd3b26-ac7b-4489-8bc8-6b3ae8d47ede",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dadd3b26-ac7b-4489-8bc8-6b3ae8d47ede",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d97e5f51-a8a8-4a28-bd8b-58e7ea7978ad",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "1079370d-4e69-416d-8a78-e2737cedf5fe",
+      "display_name": "DB2-B",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://alfredinc.com/collections/products/products/db2b?variant=35219989168290",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "4351e244-9f6c-469d-ae5a-21b2e88806f2",
+      "aesthetic_variants": [
+        {
+          "slug": "gold",
+          "display_name": "Gold",
+          "primary_color_hex": "#141318",
+          "front_image": {
+            "image_id": "dcb2a810-6f0d-493b-9dd5-08f130575e1b",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "7cc1a2b1-a4f4-45c1-ae9d-2f7fb9aeb4ac",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dcb2a810-6f0d-493b-9dd5-08f130575e1b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7cc1a2b1-a4f4-45c1-ae9d-2f7fb9aeb4ac",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e56f9363-7ccf-485a-a85c-395a3ec95ab3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d039cda0-df6c-43da-a0c3-53c6749464ca",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "chrome",
+          "display_name": "Chrome",
+          "primary_color_hex": "#1e181e",
+          "front_image": {
+            "image_id": "4c3576d7-bbf0-4651-9b9e-c9f764260ee1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "7cc1a2b1-a4f4-45c1-ae9d-2f7fb9aeb4ac",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "4c3576d7-bbf0-4651-9b9e-c9f764260ee1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7cc1a2b1-a4f4-45c1-ae9d-2f7fb9aeb4ac",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e14f0881-55b5-48b4-9e4d-aba295a9d437",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fbec3f90-1dae-4e00-a12d-c98fe17f54c0",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#000000",
+          "front_image": {
+            "image_id": "47db9828-9dcd-48ce-9436-9c8b472cd292",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "7cc1a2b1-a4f4-45c1-ae9d-2f7fb9aeb4ac",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "47db9828-9dcd-48ce-9436-9c8b472cd292",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7cc1a2b1-a4f4-45c1-ae9d-2f7fb9aeb4ac",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "404faa3d-1794-4be9-affa-ea2ccb173a25",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0d6636ac-47b0-465a-bcac-f11b6f4a490d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "479cd666-fe3c-4e6c-a16f-6760d2c79a54",
+      "display_name": "DB1 with Bluetooth",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://alfredinc.com/collections/products/products/db1-with-bluetooth?variant=38032698147009",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "4351e244-9f6c-469d-ae5a-21b2e88806f2",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#2b2b2b",
+          "manufacturer_sku": "DB1-BL",
+          "front_image": {
+            "image_id": "c5d97339-874a-45c8-9508-a2faa69b4e07",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c5d97339-874a-45c8-9508-a2faa69b4e07",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "198508df-279d-4646-a56e-5b77e5a4b442",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "436b877f-1b76-4957-9ca0-8dec826ae96f",
+      "display_name": "DB1 with Bluetooth and Z-Wave",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://alfredinc.com/collections/products/products/db1-with-bluetooth-and-z-wave?variant=38032721445057",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "4351e244-9f6c-469d-ae5a-21b2e88806f2",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#2b2b2b",
+          "manufacturer_sku": "DB1-C",
+          "front_image": {
+            "image_id": "c5d97339-874a-45c8-9508-a2faa69b4e07",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c5d97339-874a-45c8-9508-a2faa69b4e07",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "198508df-279d-4646-a56e-5b77e5a4b442",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "c85036cd-e6a7-4bfe-a224-4fa4ba56b3bb",
+      "display_name": "DB2",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://alfredinc.com/collections/products/products/db2",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "4351e244-9f6c-469d-ae5a-21b2e88806f2",
+      "aesthetic_variants": [
+        {
+          "slug": "gold",
+          "display_name": "Gold",
+          "primary_color_hex": "#1a141a",
+          "front_image": {
+            "image_id": "bcbe95c8-0635-4c24-9b11-d090f1f28d79",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "bcbe95c8-0635-4c24-9b11-d090f1f28d79",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "chrome",
+          "display_name": "Chrome",
+          "primary_color_hex": "#1b171c",
+          "front_image": {
+            "image_id": "76475814-29f6-4502-a03b-f5d221fc12f0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "76475814-29f6-4502-a03b-f5d221fc12f0",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#000000",
+          "front_image": {
+            "image_id": "96c3a22f-5e18-405a-95b5-e0507b47499a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "7cc1a2b1-a4f4-45c1-ae9d-2f7fb9aeb4ac",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "96c3a22f-5e18-405a-95b5-e0507b47499a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7cc1a2b1-a4f4-45c1-ae9d-2f7fb9aeb4ac",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a1da8696-3b49-4d98-a7f5-196f9b1a5184",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b86f127f-7cc2-44cf-870e-58c067a3e98f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "a36583d6-aa2e-4b8e-8c54-0ca382637959",
+      "display_name": "Latch M",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.latch.com/m-series",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery",
+        "wireless"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "01891d08-0aab-47ff-a506-9c6a130e17c6",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#373737",
+          "front_image": {
+            "image_id": "993e5194-3bdb-4a5a-aa7a-aa363b706c03",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "993e5194-3bdb-4a5a-aa7a-aa363b706c03",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_chrome",
+          "display_name": "Satin Chrome",
+          "primary_color_hex": "#d3d3d3",
+          "front_image": {
+            "image_id": "b4b061d1-dacb-44f1-845a-31a91ee49089",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b4b061d1-dacb-44f1-845a-31a91ee49089",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "36b92993-ae89-491a-9e5f-1d6cbff96f1b",
+      "display_name": "Latch eGenius",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.latch.com/egenius-powered-by-latch",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery",
+        "wireless"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "01891d08-0aab-47ff-a506-9c6a130e17c6",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_chrome",
+          "display_name": "Satin Chrome",
+          "primary_color_hex": "#afafaf",
+          "front_image": {
+            "image_id": "b541fb7d-a6de-4159-9f9b-940806b8029b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b541fb7d-a6de-4159-9f9b-940806b8029b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8b5e8281-6fe6-4408-abdd-05749bccf85d",
+      "display_name": "Latch C2",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.latch.com/c2",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery",
+        "wireless"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "01891d08-0aab-47ff-a506-9c6a130e17c6",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_chrome",
+          "display_name": "Satin Chrome",
+          "primary_color_hex": "#939393",
+          "front_image": {
+            "image_id": "73bbb2b1-75d7-4bcd-9bc0-eb6ca0e38d66",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "73bbb2b1-75d7-4bcd-9bc0-eb6ca0e38d66",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#333333",
+          "front_image": {
+            "image_id": "9641cb04-0cdd-4417-bf49-779ea5c7a96d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "9641cb04-0cdd-4417-bf49-779ea5c7a96d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "3aa7dcbc-5db7-4eb6-add6-d9ff87a8abf1",
+      "display_name": "Unity Entrance Lock",
+      "description": "The Unity Entrance Lock is compliant with Australian lock standards AS4145.2:2008, SL8, and D8, ensuring that it meets your security needs. It can be controlled through the Yale Access App, a key card, or the Yale Smart Keypad, providing you with multiple options for accessing your lock. With the ability to grant users one-time access, access for a set period of time, or a date range, you won't have to worry about lost keys or unauthorized access.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/au/en/products/smart-products/unity-entrance-series/yale-unity-entrance-lock",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#303032",
+          "manufacturer_sku": "YUR/DEL/1/SIL",
+          "front_image": {
+            "image_id": "3b1edab1-cc7d-4e6b-b281-5d3fab2c58c8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3b1edab1-cc7d-4e6b-b281-5d3fab2c58c8",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "b540b52d-d3dd-48d6-9fb1-1ea77e77619a",
+      "display_name": "Unity Entrance Lock Fire Rated",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/au/en/products/smart-products/unity-entrance-series/yale-unity-entrance-lock-fire-rated",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#242424",
+          "manufacturer_sku": "YUR/DEL/FR/SIL",
+          "front_image": {
+            "image_id": "09f35df8-21eb-42bb-8125-f302bdcfbb13",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "9173c14c-1ab4-445b-a892-0c5d551d9913",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "09f35df8-21eb-42bb-8125-f302bdcfbb13",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9173c14c-1ab4-445b-a892-0c5d551d9913",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8659719e-8ecc-439e-805e-b8c57e5fccfb",
+      "display_name": "YDM 3115 A",
+      "description": "The YDM3115A smart lock is the perfect solution for households with multiple guests. With this innovative door access control system, you can easily enter your home without having to remember PIN codes. Simply use RFID key tags for quick and convenient access. You can even issue single-use temporary passwords for your visitors and set schedules to allow them entry while you are away. In addition to its strong security features, the YDM3115A offers both PIN code and RFID key tag authentication methods for a 3-in-1 door access control platform.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/in/en/products/smart-products/digital-door-locks/connected-/ydm-3115",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#9b9b9b",
+          "manufacturer_sku": "YDM3115A",
+          "front_image": {
+            "image_id": "a05f9c27-c597-403d-b43a-62776995dc7a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2c303068-76c2-4113-a693-826ad74d1916",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a05f9c27-c597-403d-b43a-62776995dc7a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2c303068-76c2-4113-a693-826ad74d1916",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "64a16177-a164-43da-af1c-0870c7b39658",
+      "display_name": "YMI70A",
+      "description": "Yale's YMI70A Push & Pull 5-in-1 Access Smart Lock is a modern and sleek smart lock that allows you to easily enter your home with a simple push and pull motion, even when your hands are full. The lock can be accessed through a fingerprint scan, personalized PIN code, RFID key tag, or the Yale Access app. This smart lock is designed to complement your home and offers multiple access options for your convenience.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/ph/en/products/yale-smart-locks/yale-mortise-locks/ymi70a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#2a2f2b",
+          "manufacturer_sku": "YMI70A",
+          "front_image": {
+            "image_id": "ddd42c8e-8350-48bc-8379-76d5df36e1a8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "737fcc30-7f25-431b-942a-8c4a923d30a6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "ddd42c8e-8350-48bc-8379-76d5df36e1a8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "737fcc30-7f25-431b-942a-8c4a923d30a6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8f48032d-eee1-4bff-b5b0-051d4df63363",
+      "display_name": "YDR41A",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/in/en/products/smart-products/digital-door-locks/connected-/ydr41-vertibolt-lock",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lockbox",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#191e1f",
+          "manufacturer_sku": "Yale YDR41A",
+          "front_image": {
+            "image_id": "b29c0eb3-a057-4ea7-b75a-6b7dbcb894b2",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "3a78bc1b-1fe0-4358-8fca-c987eae96f83",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b29c0eb3-a057-4ea7-b75a-6b7dbcb894b2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3a78bc1b-1fe0-4358-8fca-c987eae96f83",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "da8e66a9-1dd7-417d-99fc-d497cd553091",
+      "display_name": "Assure Lever Keypad with Wi-Fi and Bluetooth (YRL216-WF1)",
+      "description": "The Assure Lever is a smart door upgrade that allows you to lock/unlock, share access, and track who comes and goes through your door using your app, even when you're not home. With WiFi and Bluetooth connectivity, you can use voice assistants like Amazon Alexa, Hey Google, or Siri to lock, unlock, or check the status of your door. Plus, the Assure Lever will automatically unlock as you approach and relock after the door is closed, ensuring that your door is always secure. The Yale Access App allows you to control your door from anywhere, without the need for an additional hub - WiFi Connect is included. Enable Auto-Relock to never worry about whether you forgot to lock your door, as it will always lock behind you.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lever-keypad-with-wi-fi?variant=41356967608452",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#353535",
+          "manufacturer_sku": "YRL216-WF1-0BP",
+          "front_image": {
+            "image_id": "3f38059a-6367-48e1-b246-dd360112fc4a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b52bea57-e381-43ba-a8a2-835b731c57d8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3f38059a-6367-48e1-b246-dd360112fc4a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b52bea57-e381-43ba-a8a2-835b731c57d8",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#363636",
+          "manufacturer_sku": "YRL216-WF1-BSP",
+          "front_image": {
+            "image_id": "b3b2b23d-b4a4-40de-8ce8-c667dd1c8a05",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "96c5048f-b39c-42c5-b068-9c1f0d3ee255",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3b2b23d-b4a4-40de-8ce8-c667dd1c8a05",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "96c5048f-b39c-42c5-b068-9c1f0d3ee255",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "cb311b39-ea9d-4377-a2a4-5211cd24008a",
+      "display_name": "Smart Door Lock YDM4109A",
+      "description": "The Yale YDM4109A smart lock is a convenient and secure solution for keyless home entry. With the Yale Access App, you can easily lock and unlock your door, send virtual keys to guests, and receive notifications on your smartphone. The smart lock also offers multiple access options, including fingerprint recognition and PIN code entry. Additionally, the YDM4109A features DoorSense technology to alert you if your door is ajar, and it can be opened with a mechanical key in case of an emergency. You can even power the lock with a standard 9V battery in case of a power outage.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/ae/en/products/smart-door-locks/smart-mortice-locks/smart-door-lock-ydm4109a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#1e1d19",
+          "manufacturer_sku": "YDM4109A",
+          "front_image": {
+            "image_id": "77bbebcd-2868-4f17-a92a-44a1e60f74e5",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "39c25608-126c-4889-b0c5-c2b62bd3fc44",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "77bbebcd-2868-4f17-a92a-44a1e60f74e5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "39c25608-126c-4889-b0c5-c2b62bd3fc44",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#111111",
+          "front_image": {
+            "image_id": "1997ede6-c85e-48d2-93d1-ad7ab975c9f1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "58014faa-5507-44f7-93ce-c381c6822f0b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "1997ede6-c85e-48d2-93d1-ad7ab975c9f1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "58014faa-5507-44f7-93ce-c381c6822f0b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "gold",
+          "display_name": "Gold",
+          "primary_color_hex": "#997944",
+          "front_image": {
+            "image_id": "bd83f71c-cff5-49bd-8ad3-69ed613c2e98",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4bf10c65-6a54-4e7a-ae70-f907a21e32c2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "bd83f71c-cff5-49bd-8ad3-69ed613c2e98",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4bf10c65-6a54-4e7a-ae70-f907a21e32c2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "9f2d87bd-62da-458a-b57d-080c4fee9b98",
+      "display_name": "YDF40A",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/my/en/products/smart-lock/yale-access-app-smart-lock/ydf40a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#171b1c",
+          "manufacturer_sku": "Yale YDF40A",
+          "front_image": {
+            "image_id": "de967858-1b5d-458c-a95f-c132659b0c57",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "339c1264-2b96-4a59-8197-3c9f184daa4f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "de967858-1b5d-458c-a95f-c132659b0c57",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "339c1264-2b96-4a59-8197-3c9f184daa4f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "3962cc60-73c0-4913-bd6e-e0775f2da488",
+      "display_name": "YDR50GA",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/metal-gate-smart-locks/ydr50ga",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lockbox",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#171b1c",
+          "manufacturer_sku": "Yale YDR50GA",
+          "front_image": {
+            "image_id": "6a3c1bd0-53a9-4966-a7e9-8079497c9469",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "c2bb09bf-927a-4a0b-ac9f-b335d167da9b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6a3c1bd0-53a9-4966-a7e9-8079497c9469",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c2bb09bf-927a-4a0b-ac9f-b335d167da9b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "f5c59d5f-aa25-48ac-b497-eacb01de52bc",
+      "display_name": "Assure Lock Touchscreen with Z-Wave Plus (YRD226-ZW2)",
+      "description": "The Yale Assure Lock Touchscreen with Z-Wave Plus comes in three colors; satin nickel, oil rubbed bronze, and black suede, and allows you to open your door without the need for keys. Simply enter your code on the lock's illuminated touchscreen keypad. The lock also has an Auto-Lock feature that automatically locks the door after it's closed, and also is equipped with Z-Wave technology, allowing you to connect it to other smart home systems. The lock also comes with two physical keys for added security, and you can create and release unique entry codes for trusted individuals.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lock-touchscreen-with-z-wave-plus?variant=39341912326276",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#343338",
+          "manufacturer_sku": "YRD226-ZW2-0BP",
+          "front_image": {
+            "image_id": "6b1602fe-f1bc-4d84-a034-90ad1b24dfa8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "ac560dd3-8c33-4cfe-aaae-4ebc4cf4f507",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6b1602fe-f1bc-4d84-a034-90ad1b24dfa8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ac560dd3-8c33-4cfe-aaae-4ebc4cf4f507",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#3d3d3d",
+          "manufacturer_sku": "YRD226-ZW2-BSP",
+          "front_image": {
+            "image_id": "7f8d3bad-5d70-4df7-addb-cda9432660b6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "6555b582-2363-4301-9b98-e1bb7d2d3586",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7f8d3bad-5d70-4df7-addb-cda9432660b6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6555b582-2363-4301-9b98-e1bb7d2d3586",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1d1b1c",
+          "manufacturer_sku": "YRD226-ZW2-619",
+          "front_image": {
+            "image_id": "06c3d9b4-feeb-48ca-afb9-b8cb93ab38e8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "06c3d9b4-feeb-48ca-afb9-b8cb93ab38e8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "de57d404-1a7b-4da6-8b71-efbb6d09e675",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "298a6a97-c459-46a7-8513-8ec86cf5f848",
+      "display_name": "Assure Lock 2 keypad with Wi-Fi (YRD430-WF1)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "bronze",
+          "display_name": "Bronze",
+          "primary_color_hex": "#1a1b16",
+          "manufacturer_sku": "YRD430-WF1-0BP",
+          "front_image": {
+            "image_id": "247eaa13-cf43-4af8-a359-d291fdcf03ae",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "247eaa13-cf43-4af8-a359-d291fdcf03ae",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#1a1a1a",
+          "front_image": {
+            "image_id": "1a7f1dc1-7b14-43b0-aacb-32c19227c2a2",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "1a7f1dc1-7b14-43b0-aacb-32c19227c2a2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1a1a1a",
+          "manufacturer_sku": "YRD430-WF1-619",
+          "front_image": {
+            "image_id": "6c3b915a-0851-4809-8e83-52f4fd9915e8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6c3b915a-0851-4809-8e83-52f4fd9915e8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "b6fa1522-33cd-4911-b0f4-49ebf083ced7",
+      "display_name": "YMF40A",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/my/en/products/smart-lock/yale-access-app-smart-lock/ymf40a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#141819",
+          "manufacturer_sku": "Yale YMF40A",
+          "front_image": {
+            "image_id": "448389ab-d852-4a94-9c72-a7bc0d62b0ce",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "15e2fc12-5e34-476d-9f16-07b3e865d7f9",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "448389ab-d852-4a94-9c72-a7bc0d62b0ce",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "15e2fc12-5e34-476d-9f16-07b3e865d7f9",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "f4ba55f6-45c7-47c2-bec7-b2c610bf87ee",
+      "display_name": "Unity Screen Door Lock",
+      "description": "The Yale Unity Security Screen Door Lock is a state-of-the-art solution for seamless entry into your home. With its award-winning design and innovative features, including the auto-unlock feature which unlocks your door as you approach using Bluetooth, Wi-Fi, GPS, and the Yale Access App, this lock is both convenient, secure, and complies with Australian lock regulatory standards AS4145.2:2008, SL6, and D7. Additionally, it is compatible with Apple HomeKit and can be connected to Hey Google, Samsung SmartThings, or Amazon Alexa through the Yale Connect Bridge.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/au/en/products/smart-products/unity-entrance-series/yale-unity-screen-door-lock",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#020204",
+          "front_image": {
+            "image_id": "09ab614e-c207-4067-aaf3-6fca843815dc",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "aabac630-2ffd-4b39-96df-668ce625ae0c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "09ab614e-c207-4067-aaf3-6fca843815dc",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "aabac630-2ffd-4b39-96df-668ce625ae0c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "a6036365-7268-4143-8c1e-e994a725fcf9",
+      "display_name": "Assure Lever Keypad with Wi-Fi and Bluetooth (YRL216-CBA)",
+      "description": "The Assure Lever is a smart door upgrade that allows you to lock/unlock, share access, and track who comes and goes through your door using your app, even when you're not home. With WiFi and Bluetooth connectivity, you can use voice assistants like Amazon Alexa, Hey Google, or Siri to lock, unlock, or check the status of your door. Plus, the Assure Lever will automatically unlock as you approach and relock after the door is closed, ensuring that your door is always secure. The Yale Access App allows you to control your door from anywhere, without the need for an additional hub - WiFi Connect is included. Enable Auto-Relock to never worry about whether you forgot to lock your door, as it will always lock behind you.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/collections/smart-locks/products/yale-assure-lever-keypad-with-wi-fi-and-bluetooth?variant=39341913735300",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#cfcfcf",
+          "manufacturer_sku": "YRL216-CBA-619",
+          "front_image": {
+            "image_id": "ad0ee9cc-41e6-4ca4-9c52-b89b240bd8df",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "a7910780-e671-448e-a6aa-24ed77743047",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "ad0ee9cc-41e6-4ca4-9c52-b89b240bd8df",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a7910780-e671-448e-a6aa-24ed77743047",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2751df76-2b3f-4171-a2df-c53bbaf169ab",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "06c988f8-f30a-452b-ae8c-e362058c6da5",
+      "display_name": "YMF30A",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/id/en/products/smart-lock/yale-access-app-smart-lock/ymf30a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#131718",
+          "manufacturer_sku": "Yale YMF30A",
+          "front_image": {
+            "image_id": "17cc1326-e265-49c6-9e78-3d4ec1a9766a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "9242d129-d495-4c4b-892e-29f5abe35385",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "17cc1326-e265-49c6-9e78-3d4ec1a9766a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9242d129-d495-4c4b-892e-29f5abe35385",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "bd31306f-9007-4d47-bbc9-e6b0b12e0e91",
+      "display_name": "Smart Door Lock YDM3109A",
+      "description": "The Yale YDM3109A smart lock is a high-tech solution for securing your home, allowing you to lock and unlock your door, send virtual keys to guests, and receive notifications through the Yale Access App. You can choose the access method that works best for you, whether it's using a PIN code or an RFID card or tag. Additionally, you can access remote functionalities (with the Yale Connect Wi-Fi Bridge) and use Yale's DoorSense technology to know when your door is closed or ajar. In case of tampering, this smart lock also has a tamper alarm feature. In an emergency, you can use the mechanical key override for access, and there is also an emergency power supply option using a standard 9V battery.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/ae/en/products/smart-door-locks/smart-mortice-locks/smart-door-lock-ydm3109a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#1a1915",
+          "manufacturer_sku": "YDM3109A",
+          "front_image": {
+            "image_id": "c72a28e0-a7de-4e82-b43e-8fca6c08b6e1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "f4da997c-23b6-4a09-93a8-8ca0be3bedf0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c72a28e0-a7de-4e82-b43e-8fca6c08b6e1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f4da997c-23b6-4a09-93a8-8ca0be3bedf0",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6b92dc59-83eb-4f52-b1c3-4c84a3189674",
+      "display_name": "YDD424A",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/wooden-door-smart-locks/yale-access-app-smart-locks/ydd424a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#101213",
+          "manufacturer_sku": "Yale YDD424A",
+          "front_image": {
+            "image_id": "8be3d9bb-68d7-478d-9d18-8b7bee30e173",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "ec426fd7-800f-4a38-b209-9e68964cf616",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8be3d9bb-68d7-478d-9d18-8b7bee30e173",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ec426fd7-800f-4a38-b209-9e68964cf616",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8bd6dbe4-6062-4e19-8366-60d694530c52",
+      "display_name": "Smart Lock Pro",
+      "description": "The Yale Smart Lock Pro uses the Yale Access App to allow you to control and monitor access to your home with and, available on iOS and Android smartphones. With the app, you can easily give or revoke keys to friends, house cleaners, or anyone else you choose. The Yale Smart Lock Pro offers added security by eliminating the need for physical keys that can be lost or copied. It also works with Apple HomeKit and features DoorSense™ Technology, an integrated sensor that tells you whether your door is open or closed.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/hk/en/products/digital-door-lock/yale-access-app-smart-lock/smart-lock-pro",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#b6b9be",
+          "manufacturer_sku": "ASL-03",
+          "front_image": {
+            "image_id": "59b740bf-cfe2-45a6-9b3e-e246a4e9bd05",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "59b740bf-cfe2-45a6-9b3e-e246a4e9bd05",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "e32de9c2-0161-43d7-9f9b-2b5f44c7b518",
+      "display_name": "Assure Lock Keypad with Wi-Fi and Bluetooth (YRD216-CBA)",
+      "description": "The Yale Assure Lock Keypad with WiFi and Bluetooth – an innovative door enhancement that transforms your home security. Control access, track entries, and enjoy keyless convenience through your smartphone, even from afar.With WiFi and Bluetooth connectivity, this smart lock seamlessly syncs with popular voice assistants like Amazon Alexa, Hey Google, and Siri. Voice-controlled locking and checking door status are now effortless. Experience hands-free entry as the Yale Assure Lock Keypad auto-unlocks upon your approach and relocks upon closure, ensuring unwavering security. Manage your door remotely using the intuitive Yale Access App, all without an extra hub. The Auto-Relock feature guarantees peace of mind, always keeping your door secure. Elevate your home's security with the Yale Assure Lock Keypad – where control meets cutting-edge technology. Explore keyless living today.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lock-keypad-with-wi-fi-and-bluetooth?variant=39341913800836",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#d8d3d2",
+          "manufacturer_sku": "YRD216-CBA-619",
+          "front_image": {
+            "image_id": "d468c8a5-7172-44e7-b8cd-ec1af0996fdb",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d468c8a5-7172-44e7-b8cd-ec1af0996fdb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#373236",
+          "manufacturer_sku": "YRD216-CBA-0BP",
+          "front_image": {
+            "image_id": "38db5e63-70c0-4190-a0fe-62f36118b310",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "d119c910-65c7-4c8f-a22d-58739d027753",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "38db5e63-70c0-4190-a0fe-62f36118b310",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d119c910-65c7-4c8f-a22d-58739d027753",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "2f96d8b8-7d38-4abf-8c70-3ff02bfef888",
+      "display_name": "YDR414",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/in/en/products/smart-products/digital-door-locks/connected-/ydr414-rim-lock",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#181818",
+          "manufacturer_sku": "Yale YDR414",
+          "front_image": {
+            "image_id": "60bdabe9-0a1d-4b9c-a0aa-449babf7466a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "30670fdf-6d8b-4405-9ed9-e233dd702197",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "60bdabe9-0a1d-4b9c-a0aa-449babf7466a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "30670fdf-6d8b-4405-9ed9-e233dd702197",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e92993f0-e3c7-444f-a25d-fe19425db2d3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f8254fdc-dc18-4262-929b-612c4554ec70",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "c3d9da77-4fec-4ac1-8929-9ee696b10be1",
+      "display_name": "Assure Lock 2 touchscreen (YRD450-BLE)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/pages/yale-assure-lock-2",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "bronze",
+          "display_name": "Bronze",
+          "primary_color_hex": "#1c1c1c",
+          "manufacturer_sku": "YRD450-BLE-0BP",
+          "front_image": {
+            "image_id": "c3b412c8-252a-4735-9742-bbbdf224c159",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c3b412c8-252a-4735-9742-bbbdf224c159",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#1c1c1c",
+          "manufacturer_sku": "YRD450-BLE-BSP",
+          "front_image": {
+            "image_id": "b1372a5e-82a8-4815-b71e-654116bd09b9",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b1372a5e-82a8-4815-b71e-654116bd09b9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "62f49b69-0715-47e0-b687-00661172d3e6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1c1c1c",
+          "manufacturer_sku": "YRD450-BLE-619",
+          "front_image": {
+            "image_id": "fc6416af-e058-47f1-a4a9-258b0941ed63",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fc6416af-e058-47f1-a4a9-258b0941ed63",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "02b0779f-3d10-40a1-b2e3-bf7867d320ff",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "5d15147b-a3fa-48f7-a8fd-93ba63897d18",
+      "display_name": "YDM7216A",
+      "description": "The Yale YDM4115 is a basic 3-in-1 smart lock that allows you to unlock your door using your fingerprint, PIN code, or mechanical key. This smart lock features a capacitive touch keypad, a smart screen, and a hidden fingerprint scanner for added security. It also has an operation status guide, a break-in/damage alarm, and an automatic locking function for added convenience. The YDM4115 also offers the option to purchase a remote control for added flexibility. It also comes in five colors; silver, gold, brown, matte black, and black.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/hk/en/products/digital-door-lock/yale-link-app-smart-lock/ydm7216",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#c9ac84",
+          "manufacturer_sku": "YDM7216A",
+          "front_image": {
+            "image_id": "9e0545ce-2e55-49da-a426-535ff9414dd9",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "5b2c3be4-cd7c-4351-a5b5-f9756dc04126",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "9e0545ce-2e55-49da-a426-535ff9414dd9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5b2c3be4-cd7c-4351-a5b5-f9756dc04126",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "7cbdce01-5f09-47a5-b43b-326156b65f55",
+      "display_name": "Assure Lock 2 touchscreen (YRD420-ZW2)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/pages/yale-assure-lock-2",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1c1c1c",
+          "front_image": {
+            "image_id": "fa200f89-4ec4-4c61-80ec-4d40fe6487ee",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "85e73070-3791-4658-8445-f01aa5c66ead",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fa200f89-4ec4-4c61-80ec-4d40fe6487ee",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "85e73070-3791-4658-8445-f01aa5c66ead",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9ff7b86c-b37b-4f1b-813c-1ef60410ccd4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "bad8d763-4238-47dc-84f4-0143c0a99d04",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bronze",
+          "display_name": "Bronze",
+          "primary_color_hex": "#1c1c1c",
+          "front_image": {
+            "image_id": "3e85c4f3-a741-47ce-8c2c-d8ef7cde336d",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3e85c4f3-a741-47ce-8c2c-d8ef7cde336d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e369e385-4566-46fc-8571-2d9e4b21fe76",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4cb8eca0-97fe-4608-bcd8-f7444c7e42f4",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#1c1c1c",
+          "front_image": {
+            "image_id": "e6b48b0d-5262-4f8f-bad6-846a015f11f6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "63e56e83-1b82-4b8d-9faa-f13ef180c2ca",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "e6b48b0d-5262-4f8f-bad6-846a015f11f6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "63e56e83-1b82-4b8d-9faa-f13ef180c2ca",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8acc9dd2-641a-45a2-b1c8-e6669f96c5a9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "923c7387-1176-4af9-8e7b-5b60bd4ce150",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "4a19e80d-dbb6-4826-8582-7d152babd3bc",
+      "display_name": "Assure Lock Keypad with Z-Wave Plus (YRD216-ZW2)",
+      "description": "The Yale Assure lock is designed to be seamlessly integrated into smart home and security systems such as SmartThings, Alarm.com, Honeywell, ADT, Wink and more. By using Z-Wave technology, you can remotely lock and unlock your door, create PIN codes, view access history, and receive notifications from anywhere. This lockcomes in two colros; satin nickel, oil rubbed bronze, can be easily installed in just minutes to replace your existing deadbolt, but requires a compatible hub and app, and does not utilize the Yale app. With the ability to create unique entry codes for trusted individuals and the option to delete codes at any time, you'll never have to hide a key again.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lock-keypad-with-z-wave-plus?variant=39341912785028",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#373334",
+          "manufacturer_sku": "YRD216-ZW2-0BP",
+          "front_image": {
+            "image_id": "46c00d2c-272c-47db-a69d-2086a2e245a9",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "f1e1ea08-8cb0-43f6-9400-50c6baa7fa1a",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "46c00d2c-272c-47db-a69d-2086a2e245a9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f1e1ea08-8cb0-43f6-9400-50c6baa7fa1a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "097ec62e-ef90-49e4-a7ad-ebc54b7d3ce1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "85f39edd-cbe6-4bc9-b8bf-226be726a684",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fb855b6a-7a31-4ec0-9e4a-795d46c08449",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#d8d3d2",
+          "manufacturer_sku": "YRD216-ZW2-619",
+          "front_image": {
+            "image_id": "d468c8a5-7172-44e7-b8cd-ec1af0996fdb",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d468c8a5-7172-44e7-b8cd-ec1af0996fdb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "fa1e8e42-4e42-4400-abfd-b2d98202a686",
+      "display_name": "YDR30GA",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/metal-gate-smart-locks/ydr30ga",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lockbox",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#151716",
+          "manufacturer_sku": "Yale YDR30GA",
+          "front_image": {
+            "image_id": "548b8908-8d9d-46f4-8f53-04d14a06a14e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "608cc9d3-74cd-4093-89b1-9ca4b9a0bf97",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "548b8908-8d9d-46f4-8f53-04d14a06a14e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "608cc9d3-74cd-4093-89b1-9ca4b9a0bf97",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "5fc31d7a-3c55-4d84-ae93-05005cb2ee85",
+      "display_name": "Assure Lock SL with Z-Wave Plus (YRD256-ZW2)",
+      "description": "The Yale Assure Lock SL allows you to open your door without using keys, and comes in three colors; satin nickel, oil rubbed bronze, and black suede. You can do this by entering a programmable pin code on the keypad.The lock is equipped with Z-Wave Plus technology, which allows it to easily integrate to your smart home system. You can lock and unlock the door remotely, create and share pin codes, and delete codes as needed. The lock can be easily installed to replace your existing deadbolt, and the Auto-Lock feature that automatically locks the door after it's closed.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lock-sl-with-z-wave-plus?variant=39341911834756",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#131313",
+          "manufacturer_sku": "YRD256-ZW2-619",
+          "front_image": {
+            "image_id": "7ccb152c-f70e-4103-bae8-3791ff7d58a0",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7ccb152c-f70e-4103-bae8-3791ff7d58a0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "34483380-70bf-44f3-9ff1-4f12afcad080",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#131313",
+          "manufacturer_sku": "YRD256-ZW2-0BP",
+          "front_image": {
+            "image_id": "7ee6d7b9-21fc-4873-8ac0-5fead27402c1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "5d186601-1b93-40fe-8f4f-b085468094d2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7ee6d7b9-21fc-4873-8ac0-5fead27402c1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5d186601-1b93-40fe-8f4f-b085468094d2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3ebe12af-442c-4c48-a662-c2e473e624cd",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#131313",
+          "manufacturer_sku": "YRD256-ZW2-BSP",
+          "front_image": {
+            "image_id": "618305b4-7937-4b10-b4e6-f2453d9f5437",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "a4f16eaf-d0a8-414e-9d01-160c537bcc06",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "618305b4-7937-4b10-b4e6-f2453d9f5437",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a4f16eaf-d0a8-414e-9d01-160c537bcc06",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1837ec3c-8972-469d-bc3c-46af5c3cd444",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "df190220-a03b-46e4-aa3d-2b908324e936",
+      "display_name": "J20A",
+      "description": "The Yale J20A RFID Rim Smart Lock allows you to remotely control and monitor your door's lock status from anywhere using the Yale Access App. With multiple access options including a pin code, RFID card, and the optional Yale Access app, you can easily grant access to people you trust. The app also includes an activity feed that tracks when and how your door was locked or unlocked, or if there was a break-in or damage attempt. Additionally, you can connect the lock to your smart home system for even more convenient control.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/ph/en/products/yale-smart-locks/yale-smart-rim-locks/j20a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lockbox",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#212121",
+          "manufacturer_sku": "J20A",
+          "front_image": {
+            "image_id": "5659c826-7cff-4551-b081-568f879e81d7",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b564f3eb-dda3-43d1-9516-66135063bbeb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5659c826-7cff-4551-b081-568f879e81d7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b564f3eb-dda3-43d1-9516-66135063bbeb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4d29e1e4-28fc-4add-9fe0-a07f469fb6fc",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0f022320-399f-493e-89d7-a40c14e551a8",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "d69f04d8-12f0-4f32-977b-f6ba5614fe26",
+      "display_name": "YDM7116A",
+      "description": "The Yale YDM7116 is a basic 3-in-1 smart lock that allows you to unlock your door using your fingerprint, PIN code, or mechanical key. This smart lock features a capacitive touch keypad, a smart screen, and a hidden fingerprint scanner for added security. It also has an operation status guide, a break-in/damage alarm, and an automatic locking function for added convenience. The YDM4115 also offers the option to purchase a remote control for added flexibility. It also comes in five colors; silver, gold, brown, matte black, and black.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/ph/en/products/yale-smart-locks/yale-mortise-locks/ydm7116a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#292929",
+          "manufacturer_sku": "YDM7116A",
+          "front_image": {
+            "image_id": "e28baa28-a7a2-4a8f-914a-3bcae7f89838",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4be3484b-eef4-4fd0-9cc2-5b5323f05ed2",
+            "width": 1080,
+            "height": 1080
+          },
+          "images": [
+            {
+              "image_id": "e28baa28-a7a2-4a8f-914a-3bcae7f89838",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4be3484b-eef4-4fd0-9cc2-5b5323f05ed2",
+              "width": 1080,
+              "height": 1080
+            },
+            {
+              "image_id": "170c5df6-0448-47c9-bf7f-e60dddbc397b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "a12d0655-be3e-4adb-864c-0a2a240d342f",
+      "display_name": "Doorman L3",
+      "description": "The Yale Doorman L3 lock is the latest addition to the Doorman series, offering enhanced safety and convenience features. It can be opened using a code, key fob, or app, and comes with a built-in doorbell and mechanical emergency opening from the inside. It also has emergency power from the outside using a 9 volt battery, and is suitable for use on most Swedish exterior doors. It is available in brushed and glossy surface finishes and has been designed for simplified installation to meet all Swedish requirements. The Yale Doorman L3 comes in three colors; brushed steel, black, and chromium.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/se/sv/products/smart-locks/yale-doorman-l3",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "brushed_steel",
+          "display_name": "Brushed Steel",
+          "primary_color_hex": "#212121",
+          "manufacturer_sku": "L3 ASL-07",
+          "front_image": {
+            "image_id": "461706a8-8b4c-4832-98be-06365d487c4e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b93cca60-2bd8-4b59-bad8-22952fee5305",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "461706a8-8b4c-4832-98be-06365d487c4e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b93cca60-2bd8-4b59-bad8-22952fee5305",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "chromium",
+          "display_name": "Chromium",
+          "primary_color_hex": "#262626",
+          "manufacturer_sku": "L3 ASL-07",
+          "front_image": {
+            "image_id": "16525ef7-b184-4fbd-954f-88a129f9a9ba",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2eb21b98-3033-42c5-b7b1-fa784a441463",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "16525ef7-b184-4fbd-954f-88a129f9a9ba",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2eb21b98-3033-42c5-b7b1-fa784a441463",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#202020",
+          "manufacturer_sku": "L3 ASL-07",
+          "front_image": {
+            "image_id": "6441ae3b-fe6a-4cc7-b120-bdbc4e0c8882",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "a4244943-2891-4000-ab9b-de1751bbe801",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6441ae3b-fe6a-4cc7-b120-bdbc4e0c8882",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a4244943-2891-4000-ab9b-de1751bbe801",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "7a689ee3-df63-42a3-b5e5-2d3eadeae424",
+      "display_name": "YDM4115A",
+      "description": "The Yale YDM4115 is a basic 3-in-1 smart lock that allows you to unlock your door using your fingerprint, PIN code, or mechanical key. This smart lock features a capacitive touch keypad, a smart screen, and a hidden fingerprint scanner for added security. It also has an operation status guide, a break-in/damage alarm, and an automatic locking function for added convenience. The YDM4115 also offers the option to purchase a remote control for added flexibility. It also comes in five colors; silver, gold, brown, matte black, and black.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/hk/en/products/digital-door-lock/finger-print-digital-door-lock/ydm4115",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "brown",
+          "display_name": "Brown",
+          "primary_color_hex": "#504541",
+          "manufacturer_sku": "YDM 4115 A BR",
+          "front_image": {
+            "image_id": "1737c105-1920-4d99-84d6-284dfad43855",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "1737c105-1920-4d99-84d6-284dfad43855",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "gold",
+          "display_name": "Gold",
+          "primary_color_hex": "#eace8f",
+          "manufacturer_sku": "YDM4115A",
+          "front_image": {
+            "image_id": "05e231a7-019a-44d6-ab6b-7ef58e7cd98c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "05e231a7-019a-44d6-ab6b-7ef58e7cd98c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#cac9c7",
+          "manufacturer_sku": "YDM4115A",
+          "front_image": {
+            "image_id": "8fb8c245-8531-4200-b743-6e3bf9aa8e10",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8fb8c245-8531-4200-b743-6e3bf9aa8e10",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "508d9288-df4b-455c-9700-8dfb1fcbc439",
+      "display_name": "Assure Lock 2 keypad (YRD430-BLE)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lock-2-key-free-keypad-with-bluetooth?variant=41535299321988",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#1a1b16",
+          "manufacturer_sku": "YRD430-BLE-0BP",
+          "front_image": {
+            "image_id": "247eaa13-cf43-4af8-a359-d291fdcf03ae",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "247eaa13-cf43-4af8-a359-d291fdcf03ae",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1a1a1a",
+          "manufacturer_sku": "YRD430-BLE-619",
+          "front_image": {
+            "image_id": "6c3b915a-0851-4809-8e83-52f4fd9915e8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6c3b915a-0851-4809-8e83-52f4fd9915e8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#1a1a1a",
+          "manufacturer_sku": "YRD430-BLE-BSP",
+          "front_image": {
+            "image_id": "1a7f1dc1-7b14-43b0-aacb-32c19227c2a2",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "1a7f1dc1-7b14-43b0-aacb-32c19227c2a2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "76b86b2e-cc11-4876-b895-09a2eb2d5177",
+      "display_name": "YDD724A",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/wooden-door-smart-locks/yale-access-app-smart-locks/ydd724a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#171b1c",
+          "manufacturer_sku": "Yale YDD724A",
+          "front_image": {
+            "image_id": "c31ebce1-3e3c-46e3-98b1-5a47c9738e89",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "bd0f3f45-e41a-40a9-b07a-dd8096b3d913",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c31ebce1-3e3c-46e3-98b1-5a47c9738e89",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "bd0f3f45-e41a-40a9-b07a-dd8096b3d913",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "d3dddaaf-ace7-4bd9-a7c8-53b7b05637b2",
+      "display_name": "YDM7220",
+      "description": "Yale's YDM7220 5-in-1 Access Smart Lock provides various options for door access control in your home, including fingerprint scan, personal PIN code, RFID key tag, and access through the Yale Access mobile app. With BioSecure™ technology, this lock ensures that all touch points around your home are frequently cleaned and disinfected, providing both convenience and peace of mind for you and your family. The Yale Access App allows up to 100 users to access the lock.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/ph/en/products/yale-smart-locks/yale-mortise-locks/ydm7220",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#1a1a1a",
+          "manufacturer_sku": "YDM7220",
+          "front_image": {
+            "image_id": "4b2e398a-b77f-4f65-8606-21ce50373525",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b2becef1-95a9-4276-ad1e-16022d43be53",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "4b2e398a-b77f-4f65-8606-21ce50373525",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b2becef1-95a9-4276-ad1e-16022d43be53",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9225ecad-472f-47df-b0b5-e442db90d1c9",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "72e7f0d1-45dc-41b9-8564-b890c559117f",
+      "display_name": "Linus Smart Lock",
+      "description": "Enhance the security and convenience of your home with the Yale Linus Smart Lock. This innovative door lock can be controlled remotely using the Yale Access App and a Yale Connect Wi-Fi Bridge. The Linus Smart Lock also features an auto-lock function, which will automatically lock your door after it is closed or after a specified time period. In addition, the Yale Linus Smart Lock is compatible with popular smart home systems including Apple HomeKit, Google Assistant, Amazon Alexa, and Philips Hue lighting. Choose from silver or black to match your home's style. Upgrade your door's security and functionality with the Yale Linus Smart Lock.",
+      "is_device_supported": true,
+      "product_url": "https://yalehome.co.uk/linus-smart-door-lock/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": false,
+        "can_program_access_schedules": false,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#b9bec8",
+          "manufacturer_sku": "Yale Linus Smart Lock",
+          "front_image": {
+            "image_id": "28bc948c-8db9-4889-84d9-7c73f5aae1a5",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "28bc948c-8db9-4889-84d9-7c73f5aae1a5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "98a6e8d4-d0f2-418b-a35c-2924a53f621a",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#4a4a58",
+          "manufacturer_sku": "Yale Linus Smart Lock",
+          "front_image": {
+            "image_id": "aeed6ab8-48f1-4ced-aba2-d753d77730d1",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "aeed6ab8-48f1-4ced-aba2-d753d77730d1",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "303bc573-f704-45c8-a9da-ce9f513fb304",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8ba0472e-13da-4db5-82d6-917822afdde6",
+      "display_name": "Assure Lever Touchscreen with Wi-Fi and Bluetooth (YRL226-WF1)",
+      "description": "The Assure Lever is a smart keypad lever lock that comes in satin nickel and oil rubbed bronze. It is equipped with Wi-Fi and Bluetooth technology, which enables you to remotely control the lock and share access with others using the Yale Access App. The lock also features a backlit keypad, so you can unlock your door even if you don't have your phone with you. It is compatible with voice assistants such as Alexa, Google, and Siri, and allows you to grant permanent, scheduled, or temporary access to trusted individuals. With the Assure Lever, you can easily manage and monitor the security of your home from anywhere.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lever-touchscreen-with-wi-fi?variant=41415042760836",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#000000",
+          "manufacturer_sku": "YRL226-WF1-BSP",
+          "front_image": {
+            "image_id": "fda857dd-4d75-46ae-b852-4b31141048cf",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2a13da8c-67c1-4727-b91c-51bd753e1232",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fda857dd-4d75-46ae-b852-4b31141048cf",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2a13da8c-67c1-4727-b91c-51bd753e1232",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "fad9488f-8155-4cd7-9cc4-901626c87071",
+      "display_name": "YDG413A",
+      "description": "The Yale YDG413AGlass Smart Lock is a high-tech security solution that allows up to 100 users to control and monitor their door from the convenience of the Yale Access App. With the app, you can check the status of the lock, lock and unlock the door remotely, and even grant access to visitors from afar. The smart lock also comes with a voice guide and automatic locking feature for added convenience and security. In the event of a break-in or damage, an alarm can be triggered to alert you of any potential threats. Stay safe and secure with the Yale YDG413AGlass Smart Lock.",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/my/en/products/smart-lock/yale-access-app-smart-lock/ydg413a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lockbox",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#e4e4eb",
+          "manufacturer_sku": "YDG413A",
+          "front_image": {
+            "image_id": "949b2130-69b1-4047-8dec-d4030daf4520",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "f19917b2-12c7-4863-a87c-681063a1af73",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "949b2130-69b1-4047-8dec-d4030daf4520",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f19917b2-12c7-4863-a87c-681063a1af73",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "70c0a71e-e56e-4ea2-bb54-a32f9d6633ea",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f2529199-2380-4d72-9f6b-2637de907d79",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "22b102f9-95cb-4f9f-93b3-da02c60225b4",
+      "display_name": "Assure Lock 2 Touchscreen with Bluetooth (YRD420-BLE)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lock-2-touchscreen-with-bluetooth?variant=41535298863236",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#1c1c1c",
+          "manufacturer_sku": "YRD420-BLE-BSP",
+          "front_image": {
+            "image_id": "e6b48b0d-5262-4f8f-bad6-846a015f11f6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "63e56e83-1b82-4b8d-9faa-f13ef180c2ca",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "e6b48b0d-5262-4f8f-bad6-846a015f11f6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "63e56e83-1b82-4b8d-9faa-f13ef180c2ca",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8acc9dd2-641a-45a2-b1c8-e6669f96c5a9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "923c7387-1176-4af9-8e7b-5b60bd4ce150",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1a1a1a",
+          "manufacturer_sku": "YRD420-BLE-619",
+          "front_image": {
+            "image_id": "932abb27-c10e-4dbe-8808-97c56061023b",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "932abb27-c10e-4dbe-8808-97c56061023b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "02b0779f-3d10-40a1-b2e3-bf7867d320ff",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "bad8d763-4238-47dc-84f4-0143c0a99d04",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#1c1c1c",
+          "manufacturer_sku": "YRD420-BLE-0BP",
+          "front_image": {
+            "image_id": "3e85c4f3-a741-47ce-8c2c-d8ef7cde336d",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3e85c4f3-a741-47ce-8c2c-d8ef7cde336d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "cf532beb-5221-4703-a0b5-d19772b90527",
+      "display_name": "Assure Lever Touchscreen with Wi-Fi and Bluetooth (YRL226-CBA)",
+      "description": "The Assure Lever is a smart keypad lever lock that comes in satin nickel and oil rubbed bronze. It is equipped with Wi-Fi and Bluetooth technology, which enables you to remotely control the lock and share access with others using the Yale Access App. The lock also features a backlit keypad, so you can unlock your door even if you don't have your phone with you. It is compatible with voice assistants such as Alexa, Google, and Siri, and allows you to grant permanent, scheduled, or temporary access to trusted individuals. With the Assure Lever, you can easily manage and monitor the security of your home from anywhere.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/collections/smart-locks/products/yale-assure-lever-touchscreen-with-wi-fi-and-bluetooth?variant=39341913440388",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#cfcfcf",
+          "manufacturer_sku": "YRL226-CBA-619",
+          "front_image": {
+            "image_id": "afa5255a-bbeb-4497-a69c-40de103f17e3",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "763f3b88-afd4-4d1b-92c0-b633971175a6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "afa5255a-bbeb-4497-a69c-40de103f17e3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "763f3b88-afd4-4d1b-92c0-b633971175a6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a8e627e8-9e6b-4551-96d3-5cddea390fe9",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#1f1f1f",
+          "manufacturer_sku": "YRL226-CBA-0BP",
+          "front_image": {
+            "image_id": "76e59ab0-7967-4d80-9039-b844499e0037",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "5f94ccd0-9f88-4a2a-9067-de86713d5b3e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "76e59ab0-7967-4d80-9039-b844499e0037",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5f94ccd0-9f88-4a2a-9067-de86713d5b3e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "22e03b71-2fe3-4038-a15d-1448983a409b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "fdf810df-23c6-47b8-8298-fc8998548db4",
+      "display_name": "Assure for Andersen",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/collections/patio-door-locks/products/assure-lock-for-andersen-patio-doors-standalone?variant=39337803350148",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#494947",
+          "manufacturer_sku": "YRM276-NR-BLK",
+          "front_image": {
+            "image_id": "db273bd0-a185-487f-a413-faf92fa3dc6d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "db273bd0-a185-487f-a413-faf92fa3dc6d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f95a6132-af25-46e4-a529-49ba2f1db1e3",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e9e3",
+          "manufacturer_sku": "YRM276-NR-WHT",
+          "front_image": {
+            "image_id": "d3b2cefc-3d79-489b-8a52-b298056ea8d6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d3b2cefc-3d79-489b-8a52-b298056ea8d6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d6d97ecd-15ea-47a7-8580-3986eb8c95cc",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#d3d0c9",
+          "manufacturer_sku": "YRM276-NR-619",
+          "front_image": {
+            "image_id": "74bc29df-9f83-4750-b3a1-4611ad7db92c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "74bc29df-9f83-4750-b3a1-4611ad7db92c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "38d6631e-620d-4303-a8b8-7f5111859448",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "074633a9-9909-4e36-bd33-70fd67195527",
+      "display_name": "YDR3110A",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.yalehome.com/sg/en/products/smart-door-locks/wooden-door-smart-locks/yale-access-app-smart-locks/ydr3110a",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#202123",
+          "manufacturer_sku": "Yale YDR3110A",
+          "front_image": {
+            "image_id": "7a84e5f8-6dee-4d0a-a027-fb4c86aedad6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "1cd12769-c8ca-4642-b3c4-6f8307be0de6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7a84e5f8-6dee-4d0a-a027-fb4c86aedad6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1cd12769-c8ca-4642-b3c4-6f8307be0de6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "04843698-3fda-4561-adac-eef6eeb754ae",
+      "display_name": "Assure Lock 2 keypad (YRD410-WF1)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/pages/yale-assure-lock-2",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#1a1a1a",
+          "front_image": {
+            "image_id": "861583ff-8f00-43ea-94e1-661a065c93ee",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "861583ff-8f00-43ea-94e1-661a065c93ee",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1a1a1a",
+          "front_image": {
+            "image_id": "932abb27-c10e-4dbe-8808-97c56061023b",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "932abb27-c10e-4dbe-8808-97c56061023b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bronze",
+          "display_name": "Bronze",
+          "primary_color_hex": "#1b1c17",
+          "front_image": {
+            "image_id": "b6cfe156-9072-4855-9c32-bca75cdc4a3a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b6cfe156-9072-4855-9c32-bca75cdc4a3a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "7b137eef-cbf3-4e76-9f04-77432320b3ff",
+      "display_name": "Assure Lock 2 touchscreen with Wi-Fi (YRD450-WF1)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/pages/yale-assure-lock-2",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "bronze",
+          "display_name": "Bronze",
+          "primary_color_hex": "#1c1c1c",
+          "manufacturer_sku": "YRD450-WF1-0BP",
+          "front_image": {
+            "image_id": "c3b412c8-252a-4735-9742-bbbdf224c159",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c3b412c8-252a-4735-9742-bbbdf224c159",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "274bb27f-c60b-4b68-b1b5-74fa4ed1fc4b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#1c1c1c",
+          "manufacturer_sku": "YRD450-WF1-BSP",
+          "front_image": {
+            "image_id": "b1372a5e-82a8-4815-b71e-654116bd09b9",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b1372a5e-82a8-4815-b71e-654116bd09b9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "27e9f61a-253f-437b-813b-97064ba56198",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "62f49b69-0715-47e0-b687-00661172d3e6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1c1c1c",
+          "manufacturer_sku": "YRD450-WF1-619",
+          "front_image": {
+            "image_id": "fc6416af-e058-47f1-a4a9-258b0941ed63",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fc6416af-e058-47f1-a4a9-258b0941ed63",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4aee7e06-b57c-491e-8de7-2b5ea0b90f60",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "02b0779f-3d10-40a1-b2e3-bf7867d320ff",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "2568c730-ee62-4b8e-be22-d907765f20c7",
+      "display_name": "Yale Assure Lock Touchscreen with Wi-Fi and Bluetooth (YRD226-CBA)",
+      "description": "The Yale Assure Lock Touchscreen with WiFi and Bluetooth – an advanced home security solution that seamlessly combines cutting-edge technology with elegant design. This smart lock empowers you with convenient keyless access, allowing you to lock and unlock your door via your smartphone, even when you're away. With integrated WiFi and Bluetooth connectivity, you can effortlessly control your lock using voice commands through Amazon Alexa, Hey Google, or Siri. The intuitive touchscreen interface enhances user interaction, and the Yale Access App lets you manage access remotely, eliminating the need for an additional hub. Embrace the future of home security with auto-lock functionality, ensuring your door is always secure, while the sleek design adds a touch of sophistication to your home.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/products/yale-assure-lock-touchscreen-with-wi-fi-and-bluetooth?variant=39341913112708",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#343338",
+          "manufacturer_sku": "YRD226-CBA-0BP",
+          "front_image": {
+            "image_id": "5a3921e9-27d1-40ae-88a4-bae5db155bb5",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "d119c910-65c7-4c8f-a22d-58739d027753",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5a3921e9-27d1-40ae-88a4-bae5db155bb5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d119c910-65c7-4c8f-a22d-58739d027753",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black_suede",
+          "display_name": "Black Suede",
+          "primary_color_hex": "#3d3d3d",
+          "manufacturer_sku": "YRD226-CBA-BSP",
+          "front_image": {
+            "image_id": "2f037357-1593-46ab-8b4b-0381ad2e4aec",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "d545ad86-14ea-4dc7-9aee-b5d10f48c8a2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "2f037357-1593-46ab-8b4b-0381ad2e4aec",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d545ad86-14ea-4dc7-9aee-b5d10f48c8a2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#eae6dd",
+          "manufacturer_sku": "YRD226-CBA-619",
+          "front_image": {
+            "image_id": "4757f45d-e605-48a0-acaf-b22abde35827",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "4757f45d-e605-48a0-acaf-b22abde35827",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "eecf78ec-c84d-4396-a10b-3930e203dbe6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "de57d404-1a7b-4da6-8b71-efbb6d09e675",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "97529db6-49b2-4bee-b830-7367fe4a534e",
+      "display_name": "Assure Lever Touchscreen with Z-Wave Plus (YRL226-ZW2)",
+      "description": "The Assure Lever is a smart lock that comes in satin nickel and oil rubbed bronze that can be installed on your door to provide key-free entry. It connects to your phone via Wi-Fi and Bluetooth, allowing you to lock and unlock your door, grant access to others, and monitor activity using the accompanying app. The lock also has a backlit keypad, which allows you to unlock it without your phone if needed. Additionally, you can use voice assistants such as Alexa, Google, and Siri to control the lock and check its status.",
+      "is_device_supported": true,
+      "product_url": "https://shopyalehome.com/collections/smart-locks/products/yale-assure-lever-touchscreen-with-wi-fi-and-bluetooth?variant=39341913473156",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "efb72479-e592-4993-b848-1d7d18cc1f65",
+      "aesthetic_variants": [
+        {
+          "slug": "oil_rubbed_bronze",
+          "display_name": "Oil Rubbed Bronze",
+          "primary_color_hex": "#1d1d1d",
+          "manufacturer_sku": "YRL226-ZW2-0BP",
+          "front_image": {
+            "image_id": "40333bf1-6198-4ffc-ad06-7587c764568a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b3a3da2f-f701-474d-b893-208d7624fa35",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "40333bf1-6198-4ffc-ad06-7587c764568a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b3a3da2f-f701-474d-b893-208d7624fa35",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#cbcbcb",
+          "manufacturer_sku": "YRL226-ZW2-619",
+          "front_image": {
+            "image_id": "f39bcadf-770f-47cf-84b6-2ae89ef7a266",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "f39bcadf-770f-47cf-84b6-2ae89ef7a266",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "02117f50-ec1b-428c-b896-37941a4d1b6a",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "53766a51-b491-45f0-947d-9a51876d63fe",
+      "display_name": "Connected Keypads",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/smart-locks/connected-keypads.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#dad1c6",
+          "manufacturer_sku": "FE599NX CAM 619",
+          "front_image": {
+            "image_id": "a87e5d79-d901-42d6-8eb3-467a75d481e9",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a87e5d79-d901-42d6-8eb3-467a75d481e9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6b9864a4-5165-4203-8655-dbc03d66bc20",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "ea712d5e-b401-4535-a981-38efeaa57525",
+      "display_name": "Camelot Trim Connected Keypad Deadbolt",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/BE369NXCAMFFF.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "bright_brass",
+          "display_name": "Bright Brass",
+          "primary_color_hex": "#f3e2a8",
+          "manufacturer_sku": "BE369NX CAM 605",
+          "front_image": {
+            "image_id": "4eff4ba3-80cd-418a-abc5-b2a5c490e7ed",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "759a53b1-42e7-4eb1-bc71-84bc8779f9c5",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "4eff4ba3-80cd-418a-abc5-b2a5c490e7ed",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "759a53b1-42e7-4eb1-bc71-84bc8779f9c5",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "eb56f9c9-f93b-420b-854f-718eb115a3c3",
+      "display_name": "Connect Smart Deadbolt with alarm with Camelot trim, Z-wave enabled paired with Accent Lever with Camelot trim",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/FBE469NXCAMFFFACC.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "FBE469NX CAM 716 ACC",
+          "front_image": {
+            "image_id": "89f1f693-b244-4feb-953f-67a0cbcea3d3",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "0e7c212d-592e-4a63-b94a-a34551e18bcb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "89f1f693-b244-4feb-953f-67a0cbcea3d3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0e7c212d-592e-4a63-b94a-a34551e18bcb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6e4bcc9a-f890-490c-8a41-b50372947715",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4e2f3536-e5b4-48a0-8e73-373cb6f6b03a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "30be5581-7ca0-4314-9ba4-0f453ee471fe",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "18a33b50-b183-4ff1-98cb-db408bc9614b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "FBE469NX CAM 619 ACC",
+          "front_image": {
+            "image_id": "cc553219-d322-4b3b-8504-e476f3cc1171",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "5913e66c-93d9-46a5-a496-6d37a3c648cb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "cc553219-d322-4b3b-8504-e476f3cc1171",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5913e66c-93d9-46a5-a496-6d37a3c648cb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "294bda34-b898-4651-9af6-edb9917e3cc7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "28b4547e-3f42-4de0-907c-c43814ed22f1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0f5fc059-2cc2-4509-97d1-ea77908c2a41",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fab0097d-b0f6-41c2-8648-2c46784c5902",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bright_brass",
+          "display_name": "Bright Brass",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "FBE469NX CAM 605 ACC",
+          "front_image": {
+            "image_id": "328ae1ae-b3c3-4ff5-aef5-bcf80b6d2be6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "d04fb0c5-c5c2-4056-ab18-2c6e10e3afe4",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "328ae1ae-b3c3-4ff5-aef5-bcf80b6d2be6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d04fb0c5-c5c2-4056-ab18-2c6e10e3afe4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "99ed2379-0494-4241-b46a-99b01b66f86f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1cb02a8c-5eb7-4d05-b646-fa8b738b298a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cae97d8d-a4c4-4ab7-8159-7e71d579cc4b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "20af24fb-3364-4c61-8964-1dc3cd392ed5",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "0f54b86a-2173-4414-8517-28efb4db558b",
+      "display_name": "Schlage Encode Smart WiFi Lever",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/smart-locks/encode-lever.html",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#cecdc8",
+          "front_image": {
+            "image_id": "8d519be2-ad12-4737-9c9c-bd71e531d3db",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "369e6e33-121e-42a5-a13c-e88e284215ce",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8d519be2-ad12-4737-9c9c-bd71e531d3db",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "369e6e33-121e-42a5-a13c-e88e284215ce",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "649574a3-6d60-40b1-b19a-911d94c6d152",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#3e3936",
+          "front_image": {
+            "image_id": "55bd0f83-11f3-40b6-a0c7-380d6b3f5016",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "55bd0f83-11f3-40b6-a0c7-380d6b3f5016",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#373737",
+          "front_image": {
+            "image_id": "e2b3c9bc-5262-4503-890e-d40cba75c1fc",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "313866fa-f1f4-457b-b043-6acb44c3f212",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "e2b3c9bc-5262-4503-890e-d40cba75c1fc",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8f1cc589-fb94-46f2-a9c8-5c907be4f14e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "313866fa-f1f4-457b-b043-6acb44c3f212",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#cfc5ba",
+          "front_image": {
+            "image_id": "8d519be2-ad12-4737-9c9c-bd71e531d3db",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "369e6e33-121e-42a5-a13c-e88e284215ce",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8d519be2-ad12-4737-9c9c-bd71e531d3db",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "369e6e33-121e-42a5-a13c-e88e284215ce",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "649574a3-6d60-40b1-b19a-911d94c6d152",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "0824e901-2efd-4298-9f3d-04c2cdd7f039",
+      "display_name": "Sense Smart Deadbolt with Century Trim",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.schlage.com/en/home/products/BE479CENFFF.html",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#5a352d",
+          "manufacturer_sku": "BE479 CEN 716",
+          "front_image": {
+            "image_id": "2459ea57-430c-4745-9f64-a2d8106cb5a9",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "2459ea57-430c-4745-9f64-a2d8106cb5a9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "873e1c2e-58d9-4287-b950-81e83d28ebb8",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bright_chrome",
+          "display_name": "Bright Chrome",
+          "primary_color_hex": "#6f6d69",
+          "manufacturer_sku": "BE479 CEN 625",
+          "front_image": {
+            "image_id": "54ee29c4-d6b1-4b79-83eb-a9f2bf497306",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "54ee29c4-d6b1-4b79-83eb-a9f2bf497306",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ead5ce2a-eddf-4cde-9a91-51879292dd01",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#cbbfb3",
+          "manufacturer_sku": "BE479 CEN 619",
+          "front_image": {
+            "image_id": "28f372f4-3ca7-4039-a58c-2dde42b94934",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "b7f6df95-de23-4c6b-a479-29a897b6c662",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "28f372f4-3ca7-4039-a58c-2dde42b94934",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "b7f6df95-de23-4c6b-a479-29a897b6c662",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "eb9b7729-4ab6-4082-ba2e-7cc639a4ebc8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e92901b5-f9f6-48cb-b3a3-0bb3d2ef6cce",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0ad88e1a-80ab-42f8-a554-587774674aae",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#3e3e3e",
+          "manufacturer_sku": "BE479 CEN 622",
+          "front_image": {
+            "image_id": "b01674b8-45c3-45ad-83eb-05229fa0ca68",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "0e11e944-2393-4bce-af19-d60e58066e5b",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "b01674b8-45c3-45ad-83eb-05229fa0ca68",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "0e11e944-2393-4bce-af19-d60e58066e5b",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "e2d1582f-35dc-495c-a113-0cf847656dae",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "032fb999-c74e-4222-a4d5-ea26f706f0aa",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a983428c-e601-439b-9a3c-523f7c3b251d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "0b456795-b433-41b7-a171-43b9287ecc51",
+      "display_name": "Connect Smart Deadbolt with Camelot trim, Z-wave enabled paired with Camelot Handleset and Accent Lever with Camelot trim",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/FE469NXCAMFFFACC.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "bright_brass",
+          "display_name": "Bright Brass",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "FE469NX CAM 605 ACC RH",
+          "front_image": {
+            "image_id": "328ae1ae-b3c3-4ff5-aef5-bcf80b6d2be6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "d04fb0c5-c5c2-4056-ab18-2c6e10e3afe4",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "328ae1ae-b3c3-4ff5-aef5-bcf80b6d2be6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cae97d8d-a4c4-4ab7-8159-7e71d579cc4b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "20af24fb-3364-4c61-8964-1dc3cd392ed5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d04fb0c5-c5c2-4056-ab18-2c6e10e3afe4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "99ed2379-0494-4241-b46a-99b01b66f86f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1cb02a8c-5eb7-4d05-b646-fa8b738b298a",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "FE469NX CAM 619 ACC RH",
+          "front_image": {
+            "image_id": "cc553219-d322-4b3b-8504-e476f3cc1171",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "5913e66c-93d9-46a5-a496-6d37a3c648cb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "cc553219-d322-4b3b-8504-e476f3cc1171",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5913e66c-93d9-46a5-a496-6d37a3c648cb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "294bda34-b898-4651-9af6-edb9917e3cc7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "28b4547e-3f42-4de0-907c-c43814ed22f1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0f5fc059-2cc2-4509-97d1-ea77908c2a41",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fab0097d-b0f6-41c2-8648-2c46784c5902",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "FE469NX CAM 716 ACC RH",
+          "front_image": {
+            "image_id": "89f1f693-b244-4feb-953f-67a0cbcea3d3",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "0e7c212d-592e-4a63-b94a-a34551e18bcb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "89f1f693-b244-4feb-953f-67a0cbcea3d3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0e7c212d-592e-4a63-b94a-a34551e18bcb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6e4bcc9a-f890-490c-8a41-b50372947715",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4e2f3536-e5b4-48a0-8e73-373cb6f6b03a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "30be5581-7ca0-4314-9ba4-0f453ee471fe",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "18a33b50-b183-4ff1-98cb-db408bc9614b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "5f464162-3c5d-47ef-9f4b-c15ec4aa1d83",
+      "display_name": "Connect Smart Deadbolt with Century Trim, Z-Wave Plus enabled",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/BE469ZPCENFFF.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "bright_chrome",
+          "display_name": "Bright Chrome",
+          "primary_color_hex": "#333333",
+          "manufacturer_sku": "BE469ZP CEN 625",
+          "front_image": {
+            "image_id": "17f044e9-9dec-4236-8295-f776128f8a21",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "17f044e9-9dec-4236-8295-f776128f8a21",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ea4cc3de-72d1-419a-9225-1d097d32bcc4",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#313131",
+          "manufacturer_sku": "BE469ZP CEN 619",
+          "front_image": {
+            "image_id": "3ab01cea-6c8f-4d13-bf14-9c4619512647",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3ab01cea-6c8f-4d13-bf14-9c4619512647",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "860a8425-be8d-44c0-b541-dd7e3b88bfc5",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#323232",
+          "manufacturer_sku": "BE469ZP CEN 622",
+          "front_image": {
+            "image_id": "90f46f9b-844d-4d82-983c-d3a81c9c162e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "4056fff3-52c8-430a-a5b3-6393094e2e4d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "90f46f9b-844d-4d82-983c-d3a81c9c162e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "05b0bc65-a4f1-4895-b147-247890b94756",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7bb2f367-6a01-4682-85c3-dd08f9241ee3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "74076a52-fe68-429b-82d3-da3b980e50eb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4056fff3-52c8-430a-a5b3-6393094e2e4d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#333132",
+          "manufacturer_sku": "BE469ZP CEN 716",
+          "front_image": {
+            "image_id": "eb786a4d-9690-4863-8976-a077239ada1a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "dbb4ada4-daf6-4bb1-9edb-c31de1d726e1",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "eb786a4d-9690-4863-8976-a077239ada1a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "dbb4ada4-daf6-4bb1-9edb-c31de1d726e1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3e600224-0bb9-4501-9488-1d6dadca54d9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8d876ea9-d396-47c3-916b-a48e03854da8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "455eee49-c92b-4aea-ab53-a89deee3a4f0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "89ed9ac4-2884-41d9-9b7c-ad0e8b355857",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_chrome",
+          "display_name": "Satin Chrome",
+          "primary_color_hex": "#9c9fa6",
+          "manufacturer_sku": "BE469ZP CEN 626",
+          "front_image": {
+            "image_id": "102c3f2e-6695-475c-a37b-db738a04d0fb",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e253bb66-bd24-479e-bb9e-5195965a0472",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "102c3f2e-6695-475c-a37b-db738a04d0fb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d98f177b-bb72-4917-aa60-bc8c476527ea",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e253bb66-bd24-479e-bb9e-5195965a0472",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cc9c1738-179e-4d08-8576-7ef228c0f2c2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "f30bd924-f92f-44bc-9aae-ab1ae0fcc994",
+      "display_name": "Connect Smart Deadbolt with Camelot Trim, Z-Wave Plus enabled",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/BE469ZPCAMFFF.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#353132",
+          "manufacturer_sku": "BE469ZP CAM 716",
+          "front_image": {
+            "image_id": "8d5a4139-e08f-4aa1-9994-979120c075a1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "f8c04f30-9988-423c-bc93-04107be28e3d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8d5a4139-e08f-4aa1-9994-979120c075a1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b6fed7aa-bf23-43bd-a22d-02eccb811103",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a603850e-2668-4956-ad57-fb8fe46b166f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f8c04f30-9988-423c-bc93-04107be28e3d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2003254f-26b1-4992-8d71-8788bb89e06f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d53a48bb-38e2-4478-a42e-09194dbf7463",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bright_chrome",
+          "display_name": "Bright Chrome",
+          "primary_color_hex": "#353132",
+          "manufacturer_sku": "BE469ZP CAM 625",
+          "front_image": {
+            "image_id": "3682ca67-8fdc-44a8-b65d-142b92c66208",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "d4130d35-12fe-495c-bb30-a0b454527afb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3682ca67-8fdc-44a8-b65d-142b92c66208",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d4130d35-12fe-495c-bb30-a0b454527afb",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#323232",
+          "manufacturer_sku": "BE469ZP CAM 622",
+          "front_image": {
+            "image_id": "27e86b7b-9a47-4975-96e7-172b23eb7077",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b1db0716-ec29-42c4-8cbe-c96920d89152",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "27e86b7b-9a47-4975-96e7-172b23eb7077",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b1db0716-ec29-42c4-8cbe-c96920d89152",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8a60bed2-6e98-4310-ab97-93deaef5ad7f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2ba352e1-6225-4d9a-8343-7e871f7892c6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d0d44de6-1594-486a-8d89-3cbdafb01bd9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "41c5c1f3-b004-481b-916e-a74cf0ebd1b9",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bright_brass",
+          "display_name": "Bright Brass",
+          "primary_color_hex": "#363132",
+          "manufacturer_sku": "BE469ZP CAM 605",
+          "front_image": {
+            "image_id": "d3c247b0-c10d-49aa-8c7f-336e8320d501",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "1b4c7ce6-aa9c-41d6-a64d-19f87000d13f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d3c247b0-c10d-49aa-8c7f-336e8320d501",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1b4c7ce6-aa9c-41d6-a64d-19f87000d13f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "423ff700-21fd-4ae5-bca3-c128801600c1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4422142c-021f-4e5c-8019-ae2e0db42167",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#3f3d3e",
+          "manufacturer_sku": "BE469ZP CAM 619",
+          "front_image": {
+            "image_id": "0e7756ab-cd4f-44f2-9d05-87f5f11d3698",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "85dffe48-80f1-43e2-aff6-9c4c4387c6f1",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "0e7756ab-cd4f-44f2-9d05-87f5f11d3698",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "85dffe48-80f1-43e2-aff6-9c4c4387c6f1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "75db9be4-4224-4408-8b5d-9ad631351e19",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3365ea2a-6f30-4715-90cd-cd946a8b1b9d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "39914ab3-1a22-41fb-8410-32358b693522",
+      "display_name": "Sense Smart Deadbolt with Camelot trim",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.schlage.com/en/home/products/BE479CAMFFF.html",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "bright_chrome",
+          "display_name": "Bright Chrome",
+          "primary_color_hex": "#535250",
+          "manufacturer_sku": "BE479 CAM 625",
+          "front_image": {
+            "image_id": "75659b64-48c3-4092-885b-cd88708f7799",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "75659b64-48c3-4092-885b-cd88708f7799",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9e10f2c8-fbb8-42a9-bf78-caf877ab5b5f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#323335",
+          "manufacturer_sku": "BE479 CAM 716",
+          "front_image": {
+            "image_id": "6768231b-07f0-43f2-ae60-e64f99f50a08",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "d51e3ec1-7060-4f0a-bfec-a7492dba4430",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "6768231b-07f0-43f2-ae60-e64f99f50a08",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "d51e3ec1-7060-4f0a-bfec-a7492dba4430",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "db3ae4a1-74a0-48ea-85b6-99c15046b5a8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1dfef48c-3b33-4981-ab5e-4a2516ab6901",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e4b80571-c83e-45c6-8702-f22cf37701cd",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#c9bbb2",
+          "manufacturer_sku": "BE479 CAM 619",
+          "front_image": {
+            "image_id": "e6fa45a7-ca8f-4a8b-b4bf-dca88b010138",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "9d4c28c8-d5b7-404d-bae9-5c61d08498aa",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "e6fa45a7-ca8f-4a8b-b4bf-dca88b010138",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "029bb0be-ba82-4ddc-bed1-3b6915f8d754",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9d4c28c8-d5b7-404d-bae9-5c61d08498aa",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "c0b1bead-ad96-4a79-af62-2cebf866cbad",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b2aaaf0b-7fb8-4b18-a14b-4ced696e137f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#373534",
+          "manufacturer_sku": "BE479 CAM 622",
+          "front_image": {
+            "image_id": "29e2ef53-a5b8-44f6-9fb5-5dce9b97c260",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "29e2ef53-a5b8-44f6-9fb5-5dce9b97c260",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e9b783e0-3e44-462c-b932-d0cca39eae6d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "7848eaf6-8332-4220-8669-9d2eab8343cf",
+      "display_name": "Encode Plus Smart WiFi Deadbolt",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/BE499WBCENFFF.html",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#444847",
+          "manufacturer_sku": "BE499WB CEN 619",
+          "front_image": {
+            "image_id": "cbe9581e-2c26-4572-be7f-0956f45d3b4d",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e7f91c4c-aded-4310-9920-5f74230eb7da",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "cbe9581e-2c26-4572-be7f-0956f45d3b4d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e7f91c4c-aded-4310-9920-5f74230eb7da",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cc1a6a7f-889e-4e7c-89c8-6bcfe86c8000",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5131b7ff-65c5-4b04-bfa5-64147740f7ab",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d182d3b1-a435-4bed-a4d3-8ed550561325",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#434746",
+          "manufacturer_sku": "BE499WB CAM 619",
+          "front_image": {
+            "image_id": "cbe9581e-2c26-4572-be7f-0956f45d3b4d",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e7f91c4c-aded-4310-9920-5f74230eb7da",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "cbe9581e-2c26-4572-be7f-0956f45d3b4d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e7f91c4c-aded-4310-9920-5f74230eb7da",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cc1a6a7f-889e-4e7c-89c8-6bcfe86c8000",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5131b7ff-65c5-4b04-bfa5-64147740f7ab",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d182d3b1-a435-4bed-a4d3-8ed550561325",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#404040",
+          "manufacturer_sku": "BE499WB CEN 622",
+          "front_image": {
+            "image_id": "764bbcb6-58ba-432a-a53f-7c81bd91b182",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "605d1d82-b90d-4813-9603-34ae277d5357",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "764bbcb6-58ba-432a-a53f-7c81bd91b182",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "605d1d82-b90d-4813-9603-34ae277d5357",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "902cd28d-80b8-4a4c-9333-fddc2f6904c2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a151f6c4-cc2e-4b22-aa1f-85b16c5c7c4c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9810e04d-3d8a-47fa-b4ef-063942b51325",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#443f3e",
+          "manufacturer_sku": "BE499WB CAM 716",
+          "front_image": {
+            "image_id": "d2d70211-d91e-4422-bb61-451ef09209b6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b19f4fb9-beb0-482b-8a5f-ac6b47069f3c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d2d70211-d91e-4422-bb61-451ef09209b6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b19f4fb9-beb0-482b-8a5f-ac6b47069f3c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "63ebe31b-678a-49b0-b732-53150cf65c89",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "21a9fb75-8609-45ee-8e91-66c2b90fb536",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "79e59ef6-09df-4f11-a6a1-e2b53e22f8cc",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "45652bb7-0818-4d5b-ac2e-9980d9bc8d33",
+      "display_name": "Encode Smart WiFi Deadbolt",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/BE489WBCAMFFF.html",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#3c3839",
+          "manufacturer_sku": "BE489WB CAM 716",
+          "front_image": {
+            "image_id": "62f74c82-07f0-41ee-8611-acc55d748b43",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "be7f60b3-ab83-4f11-a908-0da5078df811",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "62f74c82-07f0-41ee-8611-acc55d748b43",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "be7f60b3-ab83-4f11-a908-0da5078df811",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "651855b2-58a5-47ff-850f-299c03f74195",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a33c9891-4d25-4e04-b96c-b4b6ced8e094",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "96db2396-e80e-4676-b126-89b392a01707",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bright_chrome",
+          "display_name": "Bright Chrome",
+          "primary_color_hex": "#464646",
+          "manufacturer_sku": "BE489WB CEN 625",
+          "front_image": {
+            "image_id": "78f5056b-1471-452d-bad8-d2c6689e39fb",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e83c4f5a-df1f-4082-9bd4-eab0040e7167",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "78f5056b-1471-452d-bad8-d2c6689e39fb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e83c4f5a-df1f-4082-9bd4-eab0040e7167",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "29eff351-102a-4fc8-9fbd-1ac7b88aab13",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ce2be370-c2e2-400e-a276-f32c4e6853ab",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6137d304-6d45-4e8c-b575-eb819d5ef66a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f7ff8a1f-ad4d-471b-aac2-37e4e009236f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bright_chrome",
+          "display_name": "Bright Chrome",
+          "primary_color_hex": "#555356",
+          "manufacturer_sku": "BE489WB CAM 625",
+          "front_image": {
+            "image_id": "78f5056b-1471-452d-bad8-d2c6689e39fb",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e83c4f5a-df1f-4082-9bd4-eab0040e7167",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "78f5056b-1471-452d-bad8-d2c6689e39fb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e83c4f5a-df1f-4082-9bd4-eab0040e7167",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "29eff351-102a-4fc8-9fbd-1ac7b88aab13",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ce2be370-c2e2-400e-a276-f32c4e6853ab",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6137d304-6d45-4e8c-b575-eb819d5ef66a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f7ff8a1f-ad4d-471b-aac2-37e4e009236f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#abb8a6",
+          "manufacturer_sku": "BE489WB CEN 619",
+          "front_image": {
+            "image_id": "9a26a1ea-537a-4b9a-839a-1c3a5687b430",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "28258924-ff14-4ebf-a583-24ab2b026caf",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "9a26a1ea-537a-4b9a-839a-1c3a5687b430",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "28258924-ff14-4ebf-a583-24ab2b026caf",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "be78b8a9-f0b7-4c51-9486-20d5c8ed9f49",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cdd62bd7-8caa-4625-a076-a1112d52427d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fed3a81e-628e-482c-bf2b-50e5becfc5e7",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#3f3939",
+          "manufacturer_sku": "BE489WB CEN 625",
+          "front_image": {
+            "image_id": "62f74c82-07f0-41ee-8611-acc55d748b43",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "be7f60b3-ab83-4f11-a908-0da5078df811",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "62f74c82-07f0-41ee-8611-acc55d748b43",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "be7f60b3-ab83-4f11-a908-0da5078df811",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "651855b2-58a5-47ff-850f-299c03f74195",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a33c9891-4d25-4e04-b96c-b4b6ced8e094",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "96db2396-e80e-4676-b126-89b392a01707",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#afab9f",
+          "manufacturer_sku": "BE489WB CAM 619",
+          "front_image": {
+            "image_id": "9a26a1ea-537a-4b9a-839a-1c3a5687b430",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "28258924-ff14-4ebf-a583-24ab2b026caf",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "9a26a1ea-537a-4b9a-839a-1c3a5687b430",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "28258924-ff14-4ebf-a583-24ab2b026caf",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "be78b8a9-f0b7-4c51-9486-20d5c8ed9f49",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cdd62bd7-8caa-4625-a076-a1112d52427d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fed3a81e-628e-482c-bf2b-50e5becfc5e7",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#555356",
+          "manufacturer_sku": "BE489WB CAM 622",
+          "front_image": {
+            "image_id": "b64e1b40-bee8-458a-9e43-e9c394089ce4",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "bde58713-4c22-4b51-97f0-d2c13fa7bf5b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b64e1b40-bee8-458a-9e43-e9c394089ce4",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "bde58713-4c22-4b51-97f0-d2c13fa7bf5b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4e54f1ff-942b-4a44-bece-940a135778ac",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "af2242f8-f25c-43b4-af87-c9fcacf05658",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7eb384e4-1c05-4820-91d9-13511284c790",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#1b2121",
+          "manufacturer_sku": "BE489WB CEN 622",
+          "front_image": {
+            "image_id": "b64e1b40-bee8-458a-9e43-e9c394089ce4",
+            "width": 1000,
+            "height": 1000
+          },
+          "back_image": {
+            "image_id": "bde58713-4c22-4b51-97f0-d2c13fa7bf5b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b64e1b40-bee8-458a-9e43-e9c394089ce4",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "bde58713-4c22-4b51-97f0-d2c13fa7bf5b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4e54f1ff-942b-4a44-bece-940a135778ac",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "af2242f8-f25c-43b4-af87-c9fcacf05658",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7eb384e4-1c05-4820-91d9-13511284c790",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "c1f0b537-cd0a-47b4-9868-7c575d585972",
+      "display_name": "Connect Smart Deadbolt with alarm with Camelot Trim, Z-wave enabled",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/BE469NXCAMFFF.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "bright_chrome",
+          "display_name": "Bright Chrome",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "BE469NX CAM 625",
+          "front_image": {
+            "image_id": "9a2c5827-1015-4316-9ed2-2385411d979f",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "23c33b34-6f5a-43af-98b6-17e79a5a2fba",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "9a2c5827-1015-4316-9ed2-2385411d979f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "23c33b34-6f5a-43af-98b6-17e79a5a2fba",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f1e8f382-adcb-4aa5-b827-f1b65610f99b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "91ee8d2c-8fcc-4125-a27c-181e46eeb7f6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "08c37b6c-558f-4825-a31c-e8224ef251f1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c1e52d26-cf95-4a3f-9270-efd708b1166c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "BE469NX CAM 622",
+          "front_image": {
+            "image_id": "26a8a371-5c15-45dd-96da-20b7f33f05cb",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "44cc5491-bca6-41d1-88db-c8d3b3b1053c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "26a8a371-5c15-45dd-96da-20b7f33f05cb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "44cc5491-bca6-41d1-88db-c8d3b3b1053c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "bdc5452f-b4c2-4529-b87a-fa10d2266848",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "22b592d2-eb6d-4e96-a995-508f9a185c15",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fdc073c5-4102-49fa-9a59-0c624a0f044d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "44f5ca41-6565-4dfd-8015-c0f62a35ec06",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "bright_brass",
+          "display_name": "Bright Brass",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "BE469NX CAM 505",
+          "front_image": {
+            "image_id": "328ae1ae-b3c3-4ff5-aef5-bcf80b6d2be6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "d04fb0c5-c5c2-4056-ab18-2c6e10e3afe4",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "328ae1ae-b3c3-4ff5-aef5-bcf80b6d2be6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d04fb0c5-c5c2-4056-ab18-2c6e10e3afe4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b697f7ed-0905-4418-8621-eeccb12b74f8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1cb02a8c-5eb7-4d05-b646-fa8b738b298a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cae97d8d-a4c4-4ab7-8159-7e71d579cc4b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "20af24fb-3364-4c61-8964-1dc3cd392ed5",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "BE469NX CAM 716",
+          "front_image": {
+            "image_id": "89f1f693-b244-4feb-953f-67a0cbcea3d3",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "0e7c212d-592e-4a63-b94a-a34551e18bcb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "89f1f693-b244-4feb-953f-67a0cbcea3d3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0e7c212d-592e-4a63-b94a-a34551e18bcb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6e4bcc9a-f890-490c-8a41-b50372947715",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4e2f3536-e5b4-48a0-8e73-373cb6f6b03a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "30be5581-7ca0-4314-9ba4-0f453ee471fe",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "18a33b50-b183-4ff1-98cb-db408bc9614b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#323031",
+          "manufacturer_sku": "BE469NX CAM 619",
+          "front_image": {
+            "image_id": "cc553219-d322-4b3b-8504-e476f3cc1171",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "82f70ca8-a26b-46f4-8eff-5784e257b15f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "cc553219-d322-4b3b-8504-e476f3cc1171",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "294bda34-b898-4651-9af6-edb9917e3cc7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "28b4547e-3f42-4de0-907c-c43814ed22f1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "293d5ace-bc7b-4fe2-aeb9-fb6070baf579",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1716feeb-4cd5-4610-990c-630423d0c070",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "82f70ca8-a26b-46f4-8eff-5784e257b15f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "dff7609a-8cb2-4b74-8794-dd509c6ffa5b",
+      "display_name": "Camelot Trim Connected Keypad Deadbol",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/BE369NXCAMFFF.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#ded5ca",
+          "manufacturer_sku": "BE369NX CAM 619",
+          "front_image": {
+            "image_id": "5b93e1ae-edd6-445a-8d96-40d18f55d67f",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "9e769c3e-098f-42f0-a98c-76c6d7938604",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5b93e1ae-edd6-445a-8d96-40d18f55d67f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9e769c3e-098f-42f0-a98c-76c6d7938604",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "aged_bronze",
+          "display_name": "Aged Bronze",
+          "primary_color_hex": "#28292b",
+          "manufacturer_sku": "BE369NX CAM 716",
+          "front_image": {
+            "image_id": "f5f439f6-fc81-421b-9bba-1e2ed3bf93e1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "752269e6-6f8c-4df7-b332-2ed6d3727713",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "f5f439f6-fc81-421b-9bba-1e2ed3bf93e1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "752269e6-6f8c-4df7-b332-2ed6d3727713",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "52bf4981-b20c-467e-a73f-8ba8112547bd",
+      "display_name": "Connect Smart Deadbolt with alarm with Century trim, Z-wave enabled paired with Accent Lever with Century trim",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.schlage.com/en/home/products/FBE469NXCENFFFACC.html",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "aed289f0-9b75-46be-af18-d346b69e62b7",
+      "aesthetic_variants": [
+        {
+          "slug": "bright_chrome",
+          "display_name": "Bright Chrome",
+          "primary_color_hex": "#333132",
+          "manufacturer_sku": "FBE469NX CEN 625 ACC",
+          "front_image": {
+            "image_id": "21b3caf8-6399-406d-a573-04c2f1e78701",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "feb4e43a-b2d4-47cc-a785-162151dd9830",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "21b3caf8-6399-406d-a573-04c2f1e78701",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "feb4e43a-b2d4-47cc-a785-162151dd9830",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "98519d91-36dc-4e6d-a8d9-e2f958ccb973",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7d93528a-b00d-4fda-8d18-8063aebd06ff",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#333132",
+          "manufacturer_sku": "FBE469NX CEN 619 ACC",
+          "front_image": {
+            "image_id": "fb966f39-cad7-4a26-b55c-a158cdc77b95",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "5bd50ffa-2e39-4566-bb92-dd30174ece82",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fb966f39-cad7-4a26-b55c-a158cdc77b95",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5bd50ffa-2e39-4566-bb92-dd30174ece82",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "56c04db4-9817-4e8e-989f-82b8a625df27",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "61404465-4567-4d97-9914-f8af5833e7ea",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "44d54203-7ec7-4fa1-9909-6a4332243398",
+      "display_name": "919 Premis Contemporary Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/919-premis-contemporary-smart-lock?variant=919cnt-premis-15",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "manufacturer_sku": "919CNT PREMIS 514",
+          "front_image": {
+            "image_id": "c472f294-f8e2-42a4-b300-c149fba72e40",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c472f294-f8e2-42a4-b300-c149fba72e40",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "08d65c62-4016-4960-905d-369eeafaadf2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1a6f1ecc-0893-41cf-afc0-e575d30f4946",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "manufacturer_sku": "919CNT PREMIS 15",
+          "front_image": {
+            "image_id": "7676f449-564d-4fdb-8121-ae4bc20e1482",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7676f449-564d-4fdb-8121-ae4bc20e1482",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8de376ab-833f-4209-bd3f-bb4902449f40",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0613ead1-1986-492b-9de3-b19ebe6f2c25",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "c265558b-d6da-42f7-9ada-c9d79df0ab3a",
+      "display_name": "Obsidian Keywayless Electronic Touchscreen Smart Deadbolt with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/obsidian-keywayless-electronic-touchscreen-smart-deadbolt-with-z-wave-technology?variant=954-obn-zw-15",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#060403",
+          "manufacturer_sku": "954 OBN ZW 15",
+          "front_image": {
+            "image_id": "e573c95b-f85a-4751-bddd-4bdeb86f489a",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "e573c95b-f85a-4751-bddd-4bdeb86f489a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1bbd8406-817f-47a5-b47f-80aba20f9ffc",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "49ef7195-9226-4035-a531-d6489d03b6b1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#0e0606",
+          "manufacturer_sku": "954 OBN ZW 11P",
+          "front_image": {
+            "image_id": "845e5294-db9c-45e6-820a-c3a854d1a7f5",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "845e5294-db9c-45e6-820a-c3a854d1a7f5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cc2182e7-c310-430f-9de8-13f30101d831",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "159c58fa-16c9-4b97-a765-4e76af140e80",
+      "display_name": "Home Connect 620 Contemporary Keypad Connected Smart Lock with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/home-connect-620-contemporary-keypad-connected-smart-lock-with-z-wave-technology?variant=hc620-cnt-zw700-15-smt-rcal-rcs-cp",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#e9e2dc",
+          "manufacturer_sku": "HC620 CNT ZW700 15 SMT RCAL RCS CP",
+          "front_image": {
+            "image_id": "aacb659f-c88f-4457-ab42-3e8c11236e9f",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "b1204eba-f65e-46a7-97aa-c1bbdc00c335",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "aacb659f-c88f-4457-ab42-3e8c11236e9f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b1204eba-f65e-46a7-97aa-c1bbdc00c335",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "cdae8c7e-796d-4dbd-89b6-b93160df2125",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "54190347-46e9-4bd2-b751-a3a2ddcfcdd3",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#2a2829",
+          "manufacturer_sku": "HC620 CNT ZW700 514 SMT RCAL RCS CP",
+          "front_image": {
+            "image_id": "c236cef8-fad0-4982-b097-f57f56ed316d",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "53a1c127-949f-40b8-b119-e23455c3ab4f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c236cef8-fad0-4982-b097-f57f56ed316d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "53a1c127-949f-40b8-b119-e23455c3ab4f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "679156fb-0ad6-4dba-a30e-3499790a9574",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e96cefd4-018b-4b95-9c87-7887fa35dc8a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "dbe3dac0-bad4-42f7-b16c-c637afaaa18e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "polished_chrome",
+          "display_name": "Polished Chrome",
+          "primary_color_hex": "#f4f0f3",
+          "manufacturer_sku": "HC620 CNT ZW700 26 SMT RCAL RCS CP",
+          "front_image": {
+            "image_id": "aa26ce5d-d2d4-4407-85f9-da41fccfc140",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "15cc3bb8-90bc-42d1-8e4e-f1943b48f68f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "aa26ce5d-d2d4-4407-85f9-da41fccfc140",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "15cc3bb8-90bc-42d1-8e4e-f1943b48f68f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "16992b91-6b81-499f-85a6-5fb691b3fc71",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a6ef96ba-5606-4fe8-a42e-2a0f3de8d3f4",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#463b3a",
+          "manufacturer_sku": "HC620 CNT ZW700 11P SMT RCAL RCS CP",
+          "front_image": {
+            "image_id": "99a025e9-a0a0-497f-8ce8-594f9f48ffc0",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "c698347c-3ae8-4ad4-89f7-00a7468264ee",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "99a025e9-a0a0-497f-8ce8-594f9f48ffc0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c698347c-3ae8-4ad4-89f7-00a7468264ee",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d3be9906-8fc7-4daf-a374-f1fc7f9e575e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "16660a30-a0b3-4b0e-8fe1-961bfaf7d5ce",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "b6a3d133-7668-466f-897f-ee1ad91ab349",
+      "display_name": "910 SmartCode Traditional Electronic Deadbolt with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/910-smartcode-traditional-electronic-deadbolt-with-z-wave-technology",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#dec6b9",
+          "manufacturer_sku": "910 TRL ZW 15",
+          "front_image": {
+            "image_id": "c89e3ef5-4bce-493d-b520-c4a4ccebbc6d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c89e3ef5-4bce-493d-b520-c4a4ccebbc6d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5771c826-a2bb-47e1-b664-c3fc2ef7bea0",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "lifetime_polished_brass",
+          "display_name": "Lifetime Polished Brass",
+          "primary_color_hex": "#fef7da",
+          "manufacturer_sku": "910 TRL ZW L03",
+          "front_image": {
+            "image_id": "858b9a54-9284-47d8-b10c-84ee6ac365ef",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "858b9a54-9284-47d8-b10c-84ee6ac365ef",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "60d8ac67-b233-4579-948a-196dc18a961c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#444240",
+          "manufacturer_sku": "910 TRL ZW 11P",
+          "front_image": {
+            "image_id": "5cc81854-d6b4-4f58-b54a-b1cdf467504c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5cc81854-d6b4-4f58-b54a-b1cdf467504c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2508dc2a-7c81-4ac0-bec0-6320ea312158",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "76a5464b-0f8c-4744-ba64-85a77f8d31d8",
+      "display_name": "Halo Touch Traditional Fingerprint Wi-Fi Enabled Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/halo-touch-traditional-fingerprint-wi-fi-enabled-smart-lock?variant=959-trl-fprt-wifi-15",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#dfd6cb",
+          "manufacturer_sku": "959 TRL FPRT WIFI 15",
+          "front_image": {
+            "image_id": "71a3d455-0a2e-47e0-a30e-1c453c26f2f8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "34ecb6ce-468a-4f6b-97b3-7ac2b43de578",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "71a3d455-0a2e-47e0-a30e-1c453c26f2f8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "34ecb6ce-468a-4f6b-97b3-7ac2b43de578",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a8b54ba5-a02e-40c8-b631-83231deab89b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1e0594ee-19d7-4c81-b70b-b3d93cc6f52d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#423836",
+          "manufacturer_sku": "959 TRL FPRT WIFI 11P",
+          "front_image": {
+            "image_id": "7ce35259-8f7a-4cb5-9161-45affa347fea",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "6e02d9f9-20d0-4efb-8cf3-36b80c73c632",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7ce35259-8f7a-4cb5-9161-45affa347fea",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6e02d9f9-20d0-4efb-8cf3-36b80c73c632",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "14a2fa98-c13a-440e-a9b1-35f50b7b739c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5ed94296-2d70-4b7d-8857-948a23aca3c4",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "9cf6a80d-3aef-48ab-a14e-6f22590ec5d5",
+      "display_name": "Halo Keypad Wi-Fi Enabled Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/halo-keypad-wi-fi-enabled-smart-lock?variant=938-wifi-kypd-15",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#d9d0c7",
+          "manufacturer_sku": "938 WIFI KYPD 15",
+          "front_image": {
+            "image_id": "4e76e33f-b20e-4641-bae9-89f93dd1f136",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "555bc3b3-a19d-41cb-a360-cf1f8a19b029",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "4e76e33f-b20e-4641-bae9-89f93dd1f136",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "555bc3b3-a19d-41cb-a360-cf1f8a19b029",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a9b1abc7-8730-4a77-a980-84f7d5dad805",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a1799577-323f-4d4a-9272-2d5c988a2c7b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f112f08f-7212-469a-a65d-17d7316a21ed",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#483d3e",
+          "manufacturer_sku": "938 WIFI KYPD 11P",
+          "front_image": {
+            "image_id": "b0d0c83c-f31d-4d93-8f30-6935c0ae8b26",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "fb022d79-91ec-4d22-bf1d-231ca3fdfba0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b0d0c83c-f31d-4d93-8f30-6935c0ae8b26",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fb022d79-91ec-4d22-bf1d-231ca3fdfba0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0919436e-57f4-4393-959c-f5f8e2f4d6ca",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "72ff980d-c369-41d3-8f85-a25c635dec75",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6be68259-70f5-4021-a889-603cea8639cb",
+      "display_name": "912 SmartCode Electronic Tustin Lever with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/912-smartcode-electronic-tustin-lever-with-z-wave-technology?variant=912tnl-trl-zw-l03",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "lifetime_polished_brass",
+          "display_name": "Lifetime Polished Brass",
+          "primary_color_hex": "#ffedb4",
+          "manufacturer_sku": "912TNL TRL ZW L03",
+          "front_image": {
+            "image_id": "d6e883e3-a5da-40bf-9e2c-5987c0b126e8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d6e883e3-a5da-40bf-9e2c-5987c0b126e8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4ad731b2-016d-400b-8369-08fbb76b54f7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1437a532-a9eb-4bee-84db-a1c2f28f214c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#5f595f",
+          "manufacturer_sku": "912TNL TRL ZW 11P",
+          "front_image": {
+            "image_id": "6cd128d7-1d0c-4820-aaa6-fe0aab4a9c1f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6cd128d7-1d0c-4820-aaa6-fe0aab4a9c1f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7f3a9d8f-7bf1-45f0-a4ee-e204c5bb6c59",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "37512601-77e5-49f5-9cf4-0cbaeeac4a21",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#e9e3de",
+          "manufacturer_sku": "912TNL TRL ZW 15",
+          "front_image": {
+            "image_id": "8ec9858d-8bbe-42ba-98ca-1a67b6973ed5",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8ec9858d-8bbe-42ba-98ca-1a67b6973ed5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b356b03e-c92a-4b55-a490-fae380c1aa51",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "033042bc-0eae-4518-86b5-e42f41b9b274",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "3260a17e-1160-4ffa-ba55-b85cbf98a3ef",
+      "display_name": "Aura Bluetooth Enabled Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/aura-bluetooth-enabled-smart-lock?variant=942-ble-db-15",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#e4ddd7",
+          "manufacturer_sku": "942 BLE DB 15",
+          "front_image": {
+            "image_id": "e55b87ca-7ac6-439b-9082-26ac12098023",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "fd786795-e389-475f-90c8-a8feb4c29885",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "e55b87ca-7ac6-439b-9082-26ac12098023",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fd786795-e389-475f-90c8-a8feb4c29885",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b84a2332-9c36-4444-ba77-aa555d09c4c5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f82224e2-7906-49d3-8536-0b2e33084c0d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "216e865a-a89c-451d-a928-810993585424",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#817573",
+          "manufacturer_sku": "942 BLE DB 11P",
+          "front_image": {
+            "image_id": "07b093c3-8fde-42a4-921b-e7fc0a2becab",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "40d68f78-d67c-4c87-885a-33c9d1e80369",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "07b093c3-8fde-42a4-921b-e7fc0a2becab",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "40d68f78-d67c-4c87-885a-33c9d1e80369",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3a1e838c-2166-4bf7-a46d-313878ccf9b7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "746fb763-bc7a-43db-93aa-96def0d13b59",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "bf521c9e-a6fd-49fe-8ccb-4b4aef798e7c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#474142",
+          "manufacturer_sku": "942 BLE DB 514",
+          "front_image": {
+            "image_id": "ba2575c4-5dcf-470b-8a70-2c19f8663ac7",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "43e86aee-2fd8-4cb1-9c06-a130a66b6277",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "ba2575c4-5dcf-470b-8a70-2c19f8663ac7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "43e86aee-2fd8-4cb1-9c06-a130a66b6277",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1b9e462d-d407-497c-bcc2-eadddea7c866",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "85fd3459-c861-4da5-921d-58bd61a46c5d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "1270ce8a-432c-4d46-9e81-70eef80a20a6",
+      "display_name": "916 Smartcode Contemporary Electronic Deadbolt with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/916-smartcode-contemporary-electronic-deadbolt-with-z-wave-technology?variant=916cnt-zw500-514",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#020002",
+          "manufacturer_sku": "916CNT ZW500 514",
+          "front_image": {
+            "image_id": "c472f294-f8e2-42a4-b300-c149fba72e40",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c472f294-f8e2-42a4-b300-c149fba72e40",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "08d65c62-4016-4960-905d-369eeafaadf2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1a6f1ecc-0893-41cf-afc0-e575d30f4946",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "polished_chrome",
+          "display_name": "Polished Chrome",
+          "primary_color_hex": "#f6f6f6",
+          "manufacturer_sku": "916CNT ZW500 26",
+          "front_image": {
+            "image_id": "8d9756fc-f316-47c6-9d39-118a809a9ba5",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e66bea5e-004f-402d-95ee-e9b037c706b7",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8d9756fc-f316-47c6-9d39-118a809a9ba5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e66bea5e-004f-402d-95ee-e9b037c706b7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fec71f22-35df-477b-9fc7-0038d2093b6d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2fae3f6c-5ca9-485f-ae30-841dbf04abcb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f16ed855-80d8-422d-abe2-891d3304b9af",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#0f090a",
+          "manufacturer_sku": "916CNT ZW500 11P",
+          "front_image": {
+            "image_id": "56e8f51e-d698-4379-ab19-5cd15cfbed63",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "8c313a0d-c1da-4b58-999f-b2469088309f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "56e8f51e-d698-4379-ab19-5cd15cfbed63",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8c313a0d-c1da-4b58-999f-b2469088309f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "51c1e08e-abbd-4066-a3cd-c9047584f335",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9187ebdd-d476-4b16-9b98-9cef6ff26d7e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#dbd1ca",
+          "manufacturer_sku": "916CNT ZW500 15",
+          "front_image": {
+            "image_id": "d93fd602-f573-4c28-af1c-6f00f9e3c20d",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "201ae167-446a-4d77-bf07-404308def67b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d93fd602-f573-4c28-af1c-6f00f9e3c20d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "201ae167-446a-4d77-bf07-404308def67b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "18faa653-ec4b-43a1-91d3-c076a460202b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "943c2762-3c08-48d9-8a1a-a0c8bfad344e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5eefba73-9764-4b1e-b3c6-744cd3617f88",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "26a92720-a8f4-4937-8cda-28bf677e4910",
+      "display_name": "Home Connect 620 Traditional Keypad Connected Smart Lock with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/home-connect-620-traditional-keypad-connected-smart-lock-with-z-wave-technology?variant=hc620-trl-zw700-11p-smt-rcal-rcs-cp",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#403536",
+          "manufacturer_sku": "HC620 TRL ZW700 11P SMT RCAL RCS CP",
+          "front_image": {
+            "image_id": "a91d81a7-2c36-49c9-a39c-de7dfeaea77a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e20cde44-ff1d-48d4-8ff7-c6d7b00419ac",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a91d81a7-2c36-49c9-a39c-de7dfeaea77a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e20cde44-ff1d-48d4-8ff7-c6d7b00419ac",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e8315502-734e-4b80-b916-bef7c5f1f110",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "557b36cb-e032-4089-8d89-268d501eb404",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#efe5dd",
+          "manufacturer_sku": "HC620 TRL ZW700 15 SMT RCAL RCS CP",
+          "front_image": {
+            "image_id": "baad540c-76fe-41c7-b738-4ef2ef5d00c5",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2aa9fdd2-3e50-499b-b62f-4b5c6b4fb2c1",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "baad540c-76fe-41c7-b738-4ef2ef5d00c5",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "63fa9d07-90ca-495f-9aa9-118e5f7d5b76",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "27fcb732-f335-400c-8cf7-fa7e9af1c115",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2aa9fdd2-3e50-499b-b62f-4b5c6b4fb2c1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5cdf871e-d254-4c0f-a313-ee8d9dceb2cc",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "polished_brass",
+          "display_name": "Polished Brass",
+          "primary_color_hex": "#ffdfa7",
+          "manufacturer_sku": "HC620 TRL ZW700 L03 SMT RCAL RCS CP",
+          "front_image": {
+            "image_id": "4c5033a3-e6d4-4e42-a193-dea0831be7b3",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "53d1a495-1fa3-40f9-b17d-7e8dfed9c541",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "4c5033a3-e6d4-4e42-a193-dea0831be7b3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "53d1a495-1fa3-40f9-b17d-7e8dfed9c541",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "70dcd45d-a53e-4d9a-b617-2243d8335bd8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5c2a70eb-59aa-4baf-ab52-2122cb679088",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "21695742-be2b-4b5a-b2c4-303894f3894e",
+      "display_name": "Halo Touchscreen Wi-Fi Enabled Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/halo-touchscreen-wi-fi-enabled-smart-lock?variant=939-wifi-tscr-11p",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#050303",
+          "manufacturer_sku": "939 WIFI TSCR 11P",
+          "front_image": {
+            "image_id": "3bd0dcdc-6afa-4dc5-9732-3100ba098a46",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "ecc961d9-d37a-4c3a-b405-f64deca1944b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3bd0dcdc-6afa-4dc5-9732-3100ba098a46",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ecc961d9-d37a-4c3a-b405-f64deca1944b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "60694ccd-f762-40f4-9a7a-4129b033290d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7384781f-b665-4d80-9762-a334d929afa4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6732b5e6-22f0-4a29-b6fe-5c0f66ce0d33",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#111111",
+          "manufacturer_sku": "939 WIFI TSCR 514",
+          "front_image": {
+            "image_id": "8df27a75-36a1-4cfe-8b8c-86075d6752e4",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "5b1ebc49-1d38-4f85-be8a-0d16f8d2182f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8df27a75-36a1-4cfe-8b8c-86075d6752e4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5b1ebc49-1d38-4f85-be8a-0d16f8d2182f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e2b2250e-803d-4e69-b3d8-566509af8cc1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fbfb1716-e37e-4487-811c-00f5669895e6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "polished_chrome",
+          "display_name": "Polished Chrome",
+          "primary_color_hex": "#040404",
+          "manufacturer_sku": "939 WIFI TSCR 26",
+          "front_image": {
+            "image_id": "2b1e09a6-1537-42d6-9a7d-868abdc546d1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "593d40e6-4f54-4fc6-982d-77378e36f3f3",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "2b1e09a6-1537-42d6-9a7d-868abdc546d1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "593d40e6-4f54-4fc6-982d-77378e36f3f3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d1435d6d-7590-4d68-96d3-4bbf848639da",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ca169fab-49b4-4ea0-b415-1fffc731edb7",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#040003",
+          "manufacturer_sku": "939 WIFI TSCR 15",
+          "front_image": {
+            "image_id": "e0689cea-61da-42aa-9888-5c06f29cd7c1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "93b39020-1cb2-4520-96b2-658805338fac",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "e0689cea-61da-42aa-9888-5c06f29cd7c1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "93b39020-1cb2-4520-96b2-658805338fac",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "061a6fe2-0673-4881-b0e2-4547da9f4a3d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8adcfce1-ca4d-4bb8-afc6-cca1c9cbf247",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "1ec52fa4-7451-4114-ae2a-b62e057218dd",
+      "display_name": "916 SmartCode Traditional Electronic Deadbolt with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/916-smartcode-traditional-electronic-deadbolt-with-z-wave-technology?variant=916trl-zw-11p",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#000000",
+          "manufacturer_sku": "916TRL ZW 11P",
+          "front_image": {
+            "image_id": "a9150d30-64b8-45e3-87b6-085b6a6d688e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "0454aa43-222a-4221-b948-e00af2177da6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a9150d30-64b8-45e3-87b6-085b6a6d688e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0454aa43-222a-4221-b948-e00af2177da6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9c85340b-cd14-4ddb-9853-6bc52875208b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4a33dfce-e3ca-453f-b481-abff32a8796e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#e8e8e6",
+          "manufacturer_sku": "916TRL ZW 15",
+          "front_image": {
+            "image_id": "caf03a04-6b9e-401e-aa5b-e073b7b4c675",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2481a8f2-30a7-4219-9efb-60b4075c48d4",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "caf03a04-6b9e-401e-aa5b-e073b7b4c675",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2481a8f2-30a7-4219-9efb-60b4075c48d4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "14964af8-650a-47d2-b1b5-b43f62dfbe7b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "53dd2411-904b-4ea5-9b78-128290e632a3",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "adc24765-e75f-46fb-a484-e937ebde876b",
+      "display_name": "Halo Touch Contemporary Fingerprint Wi-Fi Enabled Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/halo-touch-contemporary-fingerprint-wi-fi-enabled-smart-lock?variant=959-cnt-fprt-wifi-15",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#e3dad1",
+          "manufacturer_sku": "959 CNT FPRT WIFI 15",
+          "front_image": {
+            "image_id": "d2093448-7a3c-4bba-b8d6-c391eed2484f",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "58a9c5ce-5e60-4ed9-8c1b-5dfe3dd7d4b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d2093448-7a3c-4bba-b8d6-c391eed2484f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "58a9c5ce-5e60-4ed9-8c1b-5dfe3dd7d4b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "732be101-d8b4-4bee-8cff-fdb9ea4f74c0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "93d2a15a-61e9-4a78-b51e-36ab62d157c3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5212aca4-93bc-4ce4-8324-6eb8a38f2039",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "00dd2114-3066-4caf-a21f-c8ddde677847",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#2d292a",
+          "manufacturer_sku": "959 CNT FPRT WIFI 514",
+          "front_image": {
+            "image_id": "263c7560-a5de-4708-bb7f-45badf065309",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "6587c967-1fbd-4d10-a27c-2f5229c1ba5b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "263c7560-a5de-4708-bb7f-45badf065309",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6587c967-1fbd-4d10-a27c-2f5229c1ba5b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6201a8b5-5d01-43a3-aa82-837d1406b52c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "aac15e47-9997-43a2-a258-4dd5a719d34e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e401e3db-fa8c-4024-8669-ecc1c79d470e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "a2b7a061-709d-4105-8c9a-67e886e29d92",
+      "display_name": "888 SmartCode Electronic Deadbolt with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/888-smartcode-electronic-deadbolt-with-z-wave-technology?variant=888-zw-15",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#b8b2ad",
+          "manufacturer_sku": "888 ZW 15",
+          "front_image": {
+            "image_id": "c780e010-8281-4954-8901-08fb3944e6eb",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "c9cb3e2d-e5f6-4d38-bc2a-c2c0ab8bbc4a",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c780e010-8281-4954-8901-08fb3944e6eb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c9cb3e2d-e5f6-4d38-bc2a-c2c0ab8bbc4a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "03bbd556-9584-48d7-a344-452a67c432cc",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a66bb591-4d33-4895-9093-32beb383c2c1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#282624",
+          "manufacturer_sku": "888 ZW 11P",
+          "front_image": {
+            "image_id": "b10f8ee4-c885-4475-a368-27404406d43b",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "26780817-960f-4161-b3ab-bdfd304a6a42",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b10f8ee4-c885-4475-a368-27404406d43b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "26780817-960f-4161-b3ab-bdfd304a6a42",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "56799f00-f26c-4d85-b7f0-fd637df65adb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4df65a81-c6b0-44bb-b409-79028a7d03a0",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "lifetime_polished_brass",
+          "display_name": "Lifetime Polished Brass",
+          "primary_color_hex": "#f9dcb2",
+          "manufacturer_sku": "888 ZW L03",
+          "front_image": {
+            "image_id": "8593f42d-212e-4f98-af8d-426245cd7312",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8593f42d-212e-4f98-af8d-426245cd7312",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "22357190-63ce-4e4c-bba7-2836ca42ba62",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "d72c925a-2bd6-4371-bb67-f3448879b1e1",
+      "display_name": "910 SmartCode Contemporary Electronic Deadbolt with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/910-smartcode-contemporary-electronic-deadbolt-with-z-wave-technology?variant=910-cnt-zw-15",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#dfdad4",
+          "manufacturer_sku": "910 CNT ZW 15",
+          "front_image": {
+            "image_id": "c0f7d695-5ad9-4c85-9be1-050aa24b4175",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c0f7d695-5ad9-4c85-9be1-050aa24b4175",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d37d9eab-0c97-43c6-8db7-ae1eae673163",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_chrome",
+          "display_name": "Satin Chrome",
+          "primary_color_hex": "#d0d0d0",
+          "manufacturer_sku": "910 CNT ZW 26D",
+          "front_image": {
+            "image_id": "9000e065-3c6c-4b1f-8a97-9e3a0a2d41e3",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "9000e065-3c6c-4b1f-8a97-9e3a0a2d41e3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "620ad74c-4dc5-46dc-a1d3-bbb4bde96499",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "polished_chrome",
+          "display_name": "Polished Chrome",
+          "primary_color_hex": "#f3f4f6",
+          "manufacturer_sku": "910 CNT ZW 26",
+          "front_image": {
+            "image_id": "3dee8019-7e71-469b-853c-17acbe4cce3d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3dee8019-7e71-469b-853c-17acbe4cce3d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1f705c91-038b-4597-8823-1eca81abee79",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#4d494f",
+          "manufacturer_sku": "910 CNT ZW 11P",
+          "front_image": {
+            "image_id": "bfd32315-8458-4154-98b5-44423a098ec8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "bfd32315-8458-4154-98b5-44423a098ec8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "56214a45-9785-42dc-abe6-66089381a095",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "b4b34a97-6336-44b9-8d33-a65c9d322e1d",
+      "display_name": "914 SmartCode Contemporary Electronic Deadbolt with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/914-smartcode-contemporary-electronic-deadbolt-with-z-wave-technology?variant=914cnt-zw500-26",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "polished_chrome",
+          "display_name": "Polished Chrome",
+          "primary_color_hex": "#f7f7f7",
+          "manufacturer_sku": "914CNT ZW500 26",
+          "front_image": {
+            "image_id": "379cbb6f-dbfc-497f-8087-5aa8f294526d",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e66bea5e-004f-402d-95ee-e9b037c706b7",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "379cbb6f-dbfc-497f-8087-5aa8f294526d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e66bea5e-004f-402d-95ee-e9b037c706b7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6cfc870f-2570-479f-b4eb-89dec554a2f3",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "84c0d156-72d8-44e1-bc30-ef8a6cf14a03",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#e2d8d1",
+          "manufacturer_sku": "914CNT ZW500 15",
+          "front_image": {
+            "image_id": "04f12d8a-f53c-4986-8a40-01726d829111",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "201ae167-446a-4d77-bf07-404308def67b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "04f12d8a-f53c-4986-8a40-01726d829111",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1d76dbe5-6c7b-46e6-9af1-595e4241d996",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "201ae167-446a-4d77-bf07-404308def67b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b915cfbb-ee13-47c2-9173-dc9399d79e4f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#474142",
+          "manufacturer_sku": "914CNT ZW500 514",
+          "front_image": {
+            "image_id": "976a81a6-8bc4-420f-8682-fc60139d20db",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "864a6b50-901e-4258-802e-149c4b617e70",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "976a81a6-8bc4-420f-8682-fc60139d20db",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "864a6b50-901e-4258-802e-149c4b617e70",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f12808fb-9c2a-44d6-bcd1-9b729226aacb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8aa6e4ab-a10f-4adf-aeb6-103824c4768d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "43e5dcbb-c261-449b-8dbc-8ece315a65dc",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#2d2827",
+          "manufacturer_sku": "914CNT ZW500 11P",
+          "front_image": {
+            "image_id": "adaf88f2-c93d-439f-9046-4b06f1675a1a",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "8c313a0d-c1da-4b58-999f-b2469088309f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "adaf88f2-c93d-439f-9046-4b06f1675a1a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8c313a0d-c1da-4b58-999f-b2469088309f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b0723bd0-771a-401b-9b74-726757510468",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "76dd5d14-6326-4698-b647-f67d9cf715fc",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3360f2ff-0007-400b-a673-104e34846f96",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "97352c90-0cdb-4df5-888c-19e5cfdb2e38",
+      "display_name": "914 SmartCode Traditional Electronic Deadbolt with Z-Wave Technology",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/914-smartcode-traditional-electronic-deadbolt-with-z-wave-technology?variant=914trl-zw-11p",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#544240",
+          "manufacturer_sku": "914TRL ZW 11P",
+          "front_image": {
+            "image_id": "1472d1df-0972-4081-874e-0fe18242f71d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "1472d1df-0972-4081-874e-0fe18242f71d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "44911dde-c392-4484-be7a-ece40916b916",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "beeb4ab2-b740-4c9c-8164-cf49bb37c008",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "lifetime_polished_brass",
+          "display_name": "Lifetime Polished Brass",
+          "primary_color_hex": "#fbe5a2",
+          "manufacturer_sku": "914TRL ZW L03",
+          "front_image": {
+            "image_id": "71ee67e0-63b1-43ce-9e85-abb8ffb9a219",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "71ee67e0-63b1-43ce-9e85-abb8ffb9a219",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ba5a102a-f506-4d95-8f12-74460820fa07",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#d8cfc6",
+          "manufacturer_sku": "914TRL ZW 15",
+          "front_image": {
+            "image_id": "a6bb740c-9967-4ce5-b319-da1be5332129",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "67aa975d-ce31-4869-ba33-08244d65a5f4",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a6bb740c-9967-4ce5-b319-da1be5332129",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "67aa975d-ce31-4869-ba33-08244d65a5f4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "68d006b3-8d38-4092-9043-4fde8e1becef",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "519a457a-01f9-4e90-820f-aa053f7576a4",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "9d9e84ab-9d95-4935-b2a2-1952aa62a4d7",
+      "display_name": "919 Premis Traditional Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.kwikset.com/products/detail/919-premis-traditional-smart-lock?variant=919trl-premis-15",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "a8abff62-5354-4939-8838-db54417d2e55",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#cfc5be",
+          "manufacturer_sku": "919TRL PREMIS 15",
+          "front_image": {
+            "image_id": "caf03a04-6b9e-401e-aa5b-e073b7b4c675",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2481a8f2-30a7-4219-9efb-60b4075c48d4",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "caf03a04-6b9e-401e-aa5b-e073b7b4c675",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "14964af8-650a-47d2-b1b5-b43f62dfbe7b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2481a8f2-30a7-4219-9efb-60b4075c48d4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "53dd2411-904b-4ea5-9b78-128290e632a3",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#000000",
+          "manufacturer_sku": "919TRL PREMIS 11P",
+          "front_image": {
+            "image_id": "a9150d30-64b8-45e3-87b6-085b6a6d688e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "0454aa43-222a-4221-b948-e00af2177da6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a9150d30-64b8-45e3-87b6-085b6a6d688e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0454aa43-222a-4221-b948-e00af2177da6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9c85340b-cd14-4ddb-9853-6bc52875208b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f8519070-c3a2-4f71-a04a-cd2edb382c51",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8cbfdb20-cbd8-48f3-bd6e-295b728062cf",
+      "display_name": "NDE Mobile Enabled Wireless Cylindrical Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.brivo.com/products/smart-locks/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "edcd4e38-a066-4502-be95-364fc54787ae",
+      "aesthetic_variants": [
+        {
+          "slug": "nickel",
+          "display_name": "Nickel",
+          "images": []
+        }
+      ]
+    },
+    {
+      "device_model_id": "47dc57d2-6493-4dea-95b1-7b63ae8395c9",
+      "display_name": "le Mobile Enabled Wireless Cylindrical Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.brivo.com/products/smart-locks/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "edcd4e38-a066-4502-be95-364fc54787ae",
+      "aesthetic_variants": [
+        {
+          "slug": "nickel",
+          "display_name": "Nickel",
+          "images": []
+        }
+      ]
+    },
+    {
+      "device_model_id": "99a5534f-32ca-408a-91b0-a395e90130d8",
+      "display_name": "Padlock E",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.iglooworks.co/hardware/padlock-e",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "padlock",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#142435",
+          "manufacturer_sku": "SP1E",
+          "front_image": {
+            "image_id": "63dc806f-e28c-491f-9c69-3dc846cc77ae",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "067b0443-1fca-4f3f-b900-ef39a7dc0d47",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "63dc806f-e28c-491f-9c69-3dc846cc77ae",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "87597536-6319-4978-a4bf-853cda84b016",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "067b0443-1fca-4f3f-b900-ef39a7dc0d47",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "08f0dd8c-a621-4d4c-9a7f-7b11f8af1723",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "aca03647-b6f5-4798-865f-cba94e86de0f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f31eaf00-3c93-4c4a-b24d-d042d0638498",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "b8782108-8e04-4b69-8149-85e73ceed959",
+      "display_name": "Mortise 2+",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/mortise-2-plus",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#171717",
+          "manufacturer_sku": "IGM4",
+          "front_image": {
+            "image_id": "bb9d3101-5709-4dd9-9267-3d689a206ae8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "ca8c8ba4-f673-47b5-93a5-4bcffbc2733c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "bb9d3101-5709-4dd9-9267-3d689a206ae8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ca8c8ba4-f673-47b5-93a5-4bcffbc2733c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f502a464-cf94-4cf1-b52c-90e34a81493e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "05df55ec-1cc0-4703-90df-f6732c2535ee",
+      "display_name": "Rim Lock for wooden doors",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/rim-lock-wooden-doors",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#1e1e1e",
+          "manufacturer_sku": "RW1X",
+          "front_image": {
+            "image_id": "df543933-29d6-4628-8fe1-ada730e410c7",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "72e3a3c6-9d21-4936-a0d6-95e10753e51c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "df543933-29d6-4628-8fe1-ada730e410c7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "72e3a3c6-9d21-4936-a0d6-95e10753e51c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "f43c1baa-2c90-45f3-b26a-3f2d342e45e4",
+      "display_name": "Push-Pull Mortise",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/push-pull-mortise",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#1d1d1d",
+          "manufacturer_sku": "MP1F",
+          "front_image": {
+            "image_id": "6ccb058e-5f4c-4f7c-b260-35e3f7009e3e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "ea51a1cc-fe09-44de-9d1d-2fe24cd68dc1",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6ccb058e-5f4c-4f7c-b260-35e3f7009e3e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ea51a1cc-fe09-44de-9d1d-2fe24cd68dc1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8f20a5c6-eebf-4a85-9afe-704837c322df",
+      "display_name": "Rim Lock for metal gates",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/rim-lock",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#000000",
+          "manufacturer_sku": "IGR1",
+          "front_image": {
+            "image_id": "d79eedb7-b189-41d3-b0b3-4920791a3cf1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "034793ad-1713-463b-896c-c667bb91d505",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d79eedb7-b189-41d3-b0b3-4920791a3cf1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "034793ad-1713-463b-896c-c667bb91d505",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c08f3c43-7d70-4dd4-bf14-cc19c6e4147e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "bdcd950e-c494-4026-91f0-a071898fd1a1",
+      "display_name": "IoT Deadbolt",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.iglooworks.co/hardware/iot-deadbolt",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#191714",
+          "front_image": {
+            "image_id": "fb8edb7a-a273-4f9e-9a61-d163ac848d16",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "1f983319-c789-401c-8e73-c647f9cd1de4",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fb8edb7a-a273-4f9e-9a61-d163ac848d16",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1f983319-c789-401c-8e73-c647f9cd1de4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a8360c97-bbdb-49f5-abae-4bf21d5d0683",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "0831ed8b-2e67-451b-8a5e-9663ed033be7",
+      "display_name": "Lever Mortise",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/lever-mortise",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#000000",
+          "manufacturer_sku": "ML5",
+          "front_image": {
+            "image_id": "5f63e466-5e67-4df5-a361-e4a479193a5e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5f63e466-5e67-4df5-a361-e4a479193a5e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "df224c21-d552-4fc1-876a-67603eda2f84",
+      "display_name": "Swing Handle Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.iglooworks.co/hardware/swing-handle",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery",
+        "hardwired"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "locker",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#262424",
+          "manufacturer_sku": "IWS1",
+          "front_image": {
+            "image_id": "c6d54717-2bf7-4ce0-9d90-02dd6624ab63",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "587915d3-0cf3-40f8-9fec-011a348a2fad",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c6d54717-2bf7-4ce0-9d90-02dd6624ab63",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "587915d3-0cf3-40f8-9fec-011a348a2fad",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "bd3a7cba-0099-4306-9d4e-66b7c58aaec2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0a0d36c7-531f-4374-a992-227123885aab",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "98170fd5-f6af-4d21-b0dd-e392a34d2537",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "bacbd491-def5-4664-8620-286a67091026",
+      "display_name": "Padlock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/padlock",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "padlock",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "blue",
+          "display_name": "Blue",
+          "primary_color_hex": "#252523",
+          "manufacturer_sku": "IGP1",
+          "front_image": {
+            "image_id": "ad4f8aaa-d64b-4e04-8777-bdf840a48280",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "ad4f8aaa-d64b-4e04-8777-bdf840a48280",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c978e72c-f7ac-4fcb-ab43-6e9a8b1919d7",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "c8db65be-e3c3-4d96-96a9-1f52bc156e31",
+      "display_name": "Mortise 2",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/mortise-2",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#171717",
+          "manufacturer_sku": "IGM3",
+          "front_image": {
+            "image_id": "6282c42c-42dc-44d4-a424-88736f222d4e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "7d1744a5-2989-4256-919e-be70eb8c8e79",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6282c42c-42dc-44d4-a424-88736f222d4e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7d1744a5-2989-4256-919e-be70eb8c8e79",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6db8d0a5-3b00-4fde-abf4-838216474d07",
+      "display_name": "Keybox 3E",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.iglooworks.co/hardware/keybox-3e",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lockbox",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "blue",
+          "display_name": "Blue",
+          "primary_color_hex": "#1b2f44",
+          "manufacturer_sku": "SK3E",
+          "front_image": {
+            "image_id": "9d273121-d3a5-421b-bd10-537af23d1283",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "78ae95f6-73fd-49cf-946d-e16635873d47",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "9d273121-d3a5-421b-bd10-537af23d1283",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a2dde43d-35d7-4539-a106-7a508d176eab",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "78ae95f6-73fd-49cf-946d-e16635873d47",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d0f0c19e-e41c-4c2c-8faf-b09762bfeec9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8150fd4f-563a-44bd-8aaf-aa8012e63e3a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1d4c6366-58fa-48c4-8af6-8ee222ad647e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "bd456e0f-cf79-41e1-a6ae-d835c520a63c",
+      "display_name": "Deadbolt 2S Metal Grey",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/deadbolt-2s-mg",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "metal_grey",
+          "display_name": "Metal Grey",
+          "primary_color_hex": "#3e3e3e",
+          "manufacturer_sku": "IGB4",
+          "front_image": {
+            "image_id": "c3f5143f-7bb2-4034-9c40-f242e009e170",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "186bfd1c-d199-4eb5-9b03-92767a47b55e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c3f5143f-7bb2-4034-9c40-f242e009e170",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "186bfd1c-d199-4eb5-9b03-92767a47b55e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2a49c7a2-cd90-46e8-82d0-03512bb11401",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "dc30735c-6634-4f67-9608-59bed875e20c",
+      "display_name": "Retrofit Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/retrofit-lock",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#1c1d1d",
+          "manufacturer_sku": "OE1",
+          "front_image": {
+            "image_id": "b5c881eb-7325-4c6f-acc0-3e4a304d26da",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b5c881eb-7325-4c6f-acc0-3e4a304d26da",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "36735ec0-25a0-413e-a722-9f528ef72ac9",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8a9c818d-c33f-4dc1-9888-2d1e2994faf2",
+      "display_name": "Keybox 3",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/keybox-3",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lockbox",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#2b2b2b",
+          "manufacturer_sku": "IGK3",
+          "front_image": {
+            "image_id": "6d0dfa4a-3a94-4a74-8d5b-5b2d8ee9b96e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6d0dfa4a-3a94-4a74-8d5b-5b2d8ee9b96e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b01f9ae3-cfb5-44a7-850c-eb2868258799",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "410aa9d9-5f63-493d-93bb-09bb0dcc2b12",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3cb1c006-c673-4990-a14b-760e163c1ee4",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "12c5a948-c4ac-4d88-aba7-9c765300295e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "82fc1532-cf95-4375-bf66-ed2f5196d9a5",
+      "display_name": "Deadbolt 2E",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.iglooworks.co/hardware/deadbolt-2e",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#131313",
+          "manufacturer_sku": "IGB4A",
+          "front_image": {
+            "image_id": "64e0c19a-ae8c-41b7-a084-0ba100ab917c",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "89813d11-7b23-4369-ba29-43ebd153bc5b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "64e0c19a-ae8c-41b7-a084-0ba100ab917c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "89813d11-7b23-4369-ba29-43ebd153bc5b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3a8c6ded-2595-4053-9ffe-3029a2c1dad3",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8f4da912-b33e-4770-8e44-1aa71b9e2028",
+      "display_name": "Gate Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.igloohome.co/products/gate-lock",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "fba9c9bd-cbf9-4ea6-8cb9-7c724da8afed",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#000000",
+          "manufacturer_sku": "RM2F",
+          "front_image": {
+            "image_id": "91d434ab-f0fd-471c-9ac1-47769c9f647b",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "fdfe53c2-a40e-46b7-8e32-d80387887448",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "91d434ab-f0fd-471c-9ac1-47769c9f647b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fdfe53c2-a40e-46b7-8e32-d80387887448",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#000000",
+          "manufacturer_sku": "RM2",
+          "front_image": {
+            "image_id": "91d434ab-f0fd-471c-9ac1-47769c9f647b",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "fdfe53c2-a40e-46b7-8e32-d80387887448",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "91d434ab-f0fd-471c-9ac1-47769c9f647b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fdfe53c2-a40e-46b7-8e32-d80387887448",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "e56928e0-aa1f-401d-9d24-b39cfa15c971",
+      "display_name": "Room Lock",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://akiles.app/en/products/smart-lock-system-room-lock",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "8a4689c5-9f27-4f69-8acb-44cbc74ee258",
+      "aesthetic_variants": [
+        {
+          "slug": "stainless_steel",
+          "display_name": "Stainless Steel",
+          "primary_color_hex": "#3d3d3b",
+          "front_image": {
+            "image_id": "bbe19079-580d-423a-ab21-fc34815e2034",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "e81231a6-6be4-43f9-b5a2-0d402d4e6a6a",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "bbe19079-580d-423a-ab21-fc34815e2034",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e81231a6-6be4-43f9-b5a2-0d402d4e6a6a",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6fb76045-e4d8-4571-9fa4-31df2d35f584",
+      "display_name": "Smart Cylinder",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://akiles.app/en/products/smart-lock-system-cylinder",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "8a4689c5-9f27-4f69-8acb-44cbc74ee258",
+      "aesthetic_variants": [
+        {
+          "slug": "stainless_steel",
+          "display_name": "Stainless Steel",
+          "primary_color_hex": "#666872",
+          "front_image": {
+            "image_id": "0d1f9aba-1fdc-4bbe-97b4-d3fa272b378a",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "0d1f9aba-1fdc-4bbe-97b4-d3fa272b378a",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "da80e834-33dc-42fe-ad82-45deab295971",
+      "display_name": "Tedee GO silver",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://tedee.com/product/tedee-go/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery",
+        "hardwired",
+        "mechanical_harvesting",
+        "wireless"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": true
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "66b21885-a833-4c0f-9464-798d655ca52c",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#d9d9db",
+          "manufacturer_sku": "TLV2.0",
+          "front_image": {
+            "image_id": "f00032fd-77bc-4e80-aa0d-e19df6b5b549",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "f00032fd-77bc-4e80-aa0d-e19df6b5b549",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3496b79b-3326-4b6c-b86c-f306c9af2e3b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "161b86d5-44f8-4edc-b85a-27bd4233561d",
+      "display_name": "Tedee PRO silver",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://tedee.com/product/lock/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery",
+        "hardwired",
+        "mechanical_harvesting",
+        "wireless"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": true
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "66b21885-a833-4c0f-9464-798d655ca52c",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#d1d1d1",
+          "manufacturer_sku": "TLV1.0",
+          "front_image": {
+            "image_id": "a3f6eee9-cb46-4fb5-83f1-4dc0003618bc",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a3f6eee9-cb46-4fb5-83f1-4dc0003618bc",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e9bf7f88-522e-444b-ae99-2baf74e78096",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "bbddcfd5-60ab-444d-9071-7691085c8d76",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "238f0178-f5c6-4ecb-823a-ad650826159b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "49eef85f-65cd-42f1-9977-799d7e26bc53",
+      "display_name": "Tedee GO black",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://tedee.com/product/tedee-go/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery",
+        "hardwired",
+        "mechanical_harvesting",
+        "wireless"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": true
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "66b21885-a833-4c0f-9464-798d655ca52c",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#474747",
+          "manufacturer_sku": "TLV2.0",
+          "front_image": {
+            "image_id": "fcc96d43-c994-452a-a668-74d80d998f64",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fcc96d43-c994-452a-a668-74d80d998f64",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c3acf944-ebec-4256-8b73-a8cfd1ba3579",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "fce2f0e3-ea3d-4e57-a69e-34f7b90277d8",
+      "display_name": "Tedee PRO black",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://tedee.com/product/lock/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery",
+        "hardwired",
+        "mechanical_harvesting",
+        "wireless"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": true
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "66b21885-a833-4c0f-9464-798d655ca52c",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#575757",
+          "manufacturer_sku": "TLV1.0",
+          "front_image": {
+            "image_id": "06bde3c7-27ed-498f-9f54-f25ab624cdee",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "06bde3c7-27ed-498f-9f54-f25ab624cdee",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b684cf4b-2446-46bf-971e-d629d04dd11d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3576452d-fddc-4c85-9472-50d862054c06",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "e58da45e-049a-493a-85ef-4190fe3a3be9",
+      "display_name": "Euro Cylinder with Pinpad",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "5d273929-b5a2-49f4-af6c-146920dc90c9",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#b0b0b0",
+          "front_image": {
+            "image_id": "92907fd0-a3d9-4cc8-9076-b743696d9259",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "92907fd0-a3d9-4cc8-9076-b743696d9259",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "2a25b183-6e9c-4d5e-b56e-25374f2719c9",
+              "width": 1400,
+              "height": 1400
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "51d22f84-cd7f-4b59-b4a2-38e6480ac9df",
+      "display_name": "Smart IoT Hotel Locks Modern edition",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.4suiteshq.com/hotel-locks/",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "1f47b69f-1c4c-469b-b9e2-2fd1fb287de8",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#3d3d3d",
+          "front_image": {
+            "image_id": "9eb962ce-b911-44f0-b08b-aad87318708b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "9eb962ce-b911-44f0-b08b-aad87318708b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "b9328a1b-244b-4821-be8a-45bf5dd1fc2c",
+      "display_name": "Intelligent Reader",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.4suiteshq.com/readers/",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "hardwired"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "unknown",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "1f47b69f-1c4c-469b-b9e2-2fd1fb287de8",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#3d3d3d",
+          "front_image": {
+            "image_id": "7f72f692-f256-47a1-bd27-8cb7c1f2052d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "7f72f692-f256-47a1-bd27-8cb7c1f2052d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "64ad25be-72a1-497e-9df9-1e6bfb67d917",
+      "display_name": "Smart IoT Hotel Locks Classic edition",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://www.4suiteshq.com/hotel-locks/",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "1f47b69f-1c4c-469b-b9e2-2fd1fb287de8",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#919191",
+          "front_image": {
+            "image_id": "05ddd630-ab7c-4754-a958-2816e9a024d3",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "05ddd630-ab7c-4754-a958-2816e9a024d3",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "e0be02ca-b939-4c09-819f-e95ad3231e8b",
+      "display_name": "SwitchBot Lock",
+      "description": "",
+      "is_device_supported": false,
+      "product_url": "https://us.switch-bot.com/collections/all/products/switchbot-lock?variant=43991839932649",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": false,
+        "can_program_access_schedules": false,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "136ee03e-7b5c-4e1f-9c75-575499bff32c",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#dbdadd",
+          "front_image": {
+            "image_id": "b6c7d37b-4fca-4008-b810-19e0d55b537b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b6c7d37b-4fca-4008-b810-19e0d55b537b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fbd1b551-8ba4-46f8-974a-394937d47648",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a7f5fe98-042e-436c-b492-49b11c0b264b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#303030",
+          "front_image": {
+            "image_id": "8b56d319-3064-42f0-99f5-9b80f35d1037",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8b56d319-3064-42f0-99f5-9b80f35d1037",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d1ae9593-f6ca-43e1-9598-908e5a77d844",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2f9d4b67-6852-4a75-aa83-f60f938cbe8c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "1a4bdd4b-ed0e-43d7-9d29-93f9883b2a04",
+      "display_name": "Guard Athena (228sl)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/228sl/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#4c4c4c",
+          "front_image": {
+            "image_id": "5d438b1a-2a7b-494e-a32b-3933a0d37932",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2996b589-eedb-4e97-aad5-30e119d2c8be",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5d438b1a-2a7b-494e-a32b-3933a0d37932",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2996b589-eedb-4e97-aad5-30e119d2c8be",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c4d47561-9147-4819-9582-4d74eabbbc0d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6ff760d0-b310-4af6-9467-442dece73a3f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "stainless_steel",
+          "display_name": "Stainless Steel",
+          "primary_color_hex": "#a8a7aa",
+          "front_image": {
+            "image_id": "c78ad3b0-9d4f-4d1f-b6ce-1bf2ae614e48",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c78ad3b0-9d4f-4d1f-b6ce-1bf2ae614e48",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9ff6fccc-5dd6-437c-ae2e-d1d21cadff60",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "baefb077-128f-43c0-81d5-222555633569",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "de6ae234-4986-4ed6-a4a9-8544558d7cb8",
+      "display_name": "Lockly Flex Touch Fingerprint Deadbolt",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://lockly.com/products/lockly-flex-touch-deadbolt",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#ede7e4",
+          "manufacturer_sku": "PGD7YSN",
+          "front_image": {
+            "image_id": "6c4b18fe-5f65-4c43-bc83-229d904b86c8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6c4b18fe-5f65-4c43-bc83-229d904b86c8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e4365879-dc87-4adb-b9b3-430d051ba13e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "e09dbae6-0bf6-45e5-92c6-51d88c293600",
+      "display_name": "Guard Athena (228sw)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/228sw/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "stainless_steel",
+          "display_name": "Stainless Steel",
+          "primary_color_hex": "#e0e0de",
+          "front_image": {
+            "image_id": "ff29c791-08b7-45a9-b0a5-87316d3048e2",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "08fcdb22-093f-4cda-b89b-05d3bab1ffa2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "ff29c791-08b7-45a9-b0a5-87316d3048e2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "08fcdb22-093f-4cda-b89b-05d3bab1ffa2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f7944ead-8d37-4d33-b8b9-2e9b817325e9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d48c9367-da15-44d6-9690-a8ffb636866f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#414141",
+          "front_image": {
+            "image_id": "8db7e19f-411d-41d5-b5ff-c7d832f82bb6",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "60445f0c-f130-4fa6-b738-e98834d0d691",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8db7e19f-411d-41d5-b5ff-c7d832f82bb6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "60445f0c-f130-4fa6-b738-e98834d0d691",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "d0a37426-8ff9-4146-8855-a7e11c8502fe",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "98a991c9-a97d-4d79-9896-c3350fe0e61e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "eaa54772-629e-4247-b567-8a622f4d25b6",
+      "display_name": "Guard Latch (679l)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/679l/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#2d2d2d",
+          "front_image": {
+            "image_id": "5b583fa4-2538-4964-93b9-473ce7fbca72",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "fdd93eb0-9fb5-422b-a7f1-5ceb0cccf7eb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5b583fa4-2538-4964-93b9-473ce7fbca72",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fdd93eb0-9fb5-422b-a7f1-5ceb0cccf7eb",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#333333",
+          "front_image": {
+            "image_id": "9cf829af-1fba-4c03-a32d-efec609d4cab",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "ec1341f1-2c1a-4a55-84ac-169460d5fd0c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "9cf829af-1fba-4c03-a32d-efec609d4cab",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ec1341f1-2c1a-4a55-84ac-169460d5fd0c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7c390a01-2efb-4d50-9346-ad0d7bd1bc9c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "2fba058b-4a11-454a-b9c2-0767a788f5f4",
+      "display_name": "Duo Compact (678)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/678w/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "images": []
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#2e2e2e",
+          "front_image": {
+            "image_id": "65cfdba1-4e23-437b-b4d5-c7083e9d94fd",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "7b105560-5bb4-41c7-804a-0664a9e485ad",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "65cfdba1-4e23-437b-b4d5-c7083e9d94fd",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7b105560-5bb4-41c7-804a-0664a9e485ad",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "92b97b16-a101-4ad9-8d85-e3c4383595f3",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "9ac83d4c-7ac6-48f7-9700-ee2934fc77c8",
+      "display_name": "Access Touch (7a)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/7a/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "manufacturer_sku": "PGD7AVB",
+          "images": []
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "manufacturer_sku": "PGD7AMB",
+          "images": []
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#d1ccc9",
+          "manufacturer_sku": "PGD7ASN",
+          "front_image": {
+            "image_id": "828bae9b-0570-4df3-9783-35b59e15c994",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "828bae9b-0570-4df3-9783-35b59e15c994",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "128a7a47-f177-4076-85d8-132b6370ce05",
+      "display_name": "Secure Pro Smart Lock (Lever)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://lockly.com/products/lockly-secure-pro?variant=19786767368251",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#252527",
+          "manufacturer_sku": "PGD628WMB",
+          "front_image": {
+            "image_id": "dcfdcaf3-f7c8-469d-961e-2d1302c9de78",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "6bc7e4af-1567-45c9-9f38-1473f62d8d34",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dcfdcaf3-f7c8-469d-961e-2d1302c9de78",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6bc7e4af-1567-45c9-9f38-1473f62d8d34",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#151515",
+          "manufacturer_sku": "PGD628WVB",
+          "front_image": {
+            "image_id": "dc809fc3-02c8-415b-89bf-779cf9596466",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "39ca6034-2bc6-4d02-b745-a3de7c4717d1",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dc809fc3-02c8-415b-89bf-779cf9596466",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "39ca6034-2bc6-4d02-b745-a3de7c4717d1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "29de381a-a9f7-43ed-a15c-871589a6f041",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#98938d",
+          "manufacturer_sku": "PGD628WSN",
+          "front_image": {
+            "image_id": "42f2ea13-7206-4698-aede-87e399f9a269",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "42f2ea13-7206-4698-aede-87e399f9a269",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5527a406-6f10-4559-9746-c1df5f909622",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "606bd183-a44d-4d22-8b33-6abe43bbda12",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "433a3c3e-6430-40a2-aa66-aa6aedeb7c9a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2aaac0d0-b9e2-4bc4-a99f-d90032d12808",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6106a52f-b625-4fbc-b0e4-f1cb2a43a554",
+      "display_name": "Secure Plus Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://lockly.com/products/lockly-secure-advanced-smart-lock-door?variant=21228386549819",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#a8a7aa",
+          "manufacturer_sku": "PGD728FSN",
+          "front_image": {
+            "image_id": "c78ad3b0-9d4f-4d1f-b6ce-1bf2ae614e48",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c78ad3b0-9d4f-4d1f-b6ce-1bf2ae614e48",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9ff6fccc-5dd6-437c-ae2e-d1d21cadff60",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "baefb077-128f-43c0-81d5-222555633569",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#323232",
+          "manufacturer_sku": "PGD728FMB",
+          "front_image": {
+            "image_id": "e3cfee54-825a-43a0-9e75-d814979e8a54",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "e3cfee54-825a-43a0-9e75-d814979e8a54",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#3e3e3e",
+          "manufacturer_sku": "PGD728FVB",
+          "front_image": {
+            "image_id": "2c3a9343-be1e-4017-a99e-bb7265b76fa6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "2c3a9343-be1e-4017-a99e-bb7265b76fa6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "165ad520-262e-47bb-baf9-773e80cc0460",
+      "display_name": "Guard Defender (238l)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/238l/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "images": []
+        },
+        {
+          "slug": "stainless_steel",
+          "display_name": "Stainless Steel",
+          "images": []
+        }
+      ]
+    },
+    {
+      "device_model_id": "2d6806b9-0b58-49e9-9658-18bdd819778d",
+      "display_name": "Guard Vision Duo (698D)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/698d/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": true
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#121212",
+          "front_image": {
+            "image_id": "ee179c77-23a4-4869-960b-ef6b9309ab60",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "ee179c77-23a4-4869-960b-ef6b9309ab60",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ff831c34-cba2-4293-a01f-809d84bc7ac0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "646ed39c-f0a5-4ca5-99f5-90ce8c023db7",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "stainless_steel",
+          "display_name": "Stainless Steel",
+          "primary_color_hex": "#313131",
+          "front_image": {
+            "image_id": "5edf99fc-db78-45c6-9d19-21f2679948c4",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5edf99fc-db78-45c6-9d19-21f2679948c4",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "8ee05f4f-8feb-4e55-a144-dc45c6fef113",
+      "display_name": "Guard Fingerprint Deadbolt (728fz)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/728fz/",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "images": []
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#4c4c4c",
+          "front_image": {
+            "image_id": "5d438b1a-2a7b-494e-a32b-3933a0d37932",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2996b589-eedb-4e97-aad5-30e119d2c8be",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5d438b1a-2a7b-494e-a32b-3933a0d37932",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2996b589-eedb-4e97-aad5-30e119d2c8be",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c4d47561-9147-4819-9582-4d74eabbbc0d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6ff760d0-b310-4af6-9467-442dece73a3f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#484848",
+          "front_image": {
+            "image_id": "cd18fa34-fc62-4919-8bdb-74cd5c0abd5f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "cd18fa34-fc62-4919-8bdb-74cd5c0abd5f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f6027b04-275d-4805-b660-8e7f83a72ab8",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "1519c70d-19d3-448c-b1d6-814f0bc89b20",
+      "display_name": "Vision Doorbell Camera Smart Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://lockly.com/collections/door-lock/products/lockly-vision-doorbell-camera-smart-lock",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": true
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#1c1e1f",
+          "manufacturer_sku": "PGD798MB",
+          "front_image": {
+            "image_id": "eeb7da76-229d-4b0a-a9ed-e60e58ee14c1",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "1b4e81a2-6f70-49a0-bf71-539b6fed8c48",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "eeb7da76-229d-4b0a-a9ed-e60e58ee14c1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8e56da51-1c64-4417-b6fd-52210c670997",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1b4e81a2-6f70-49a0-bf71-539b6fed8c48",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#1e1e1e",
+          "manufacturer_sku": "PGD798VB",
+          "front_image": {
+            "image_id": "dff31ef4-22ae-4586-995d-697e4e83f97f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dff31ef4-22ae-4586-995d-697e4e83f97f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "73747c23-f541-410e-be56-52b77971fc3b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2a79c717-dcf6-46d4-a603-f89f8aab0558",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#1e1e1e",
+          "manufacturer_sku": "PGD798SN",
+          "front_image": {
+            "image_id": "b5d49786-3fcb-40b2-ad3f-6e211e4df190",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b5d49786-3fcb-40b2-ad3f-6e211e4df190",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fdf60826-f22a-484f-8f8a-38c33dd3c173",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "efd9f30f-5727-4732-83fd-35ed05c3c2b2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1823b83d-ab5b-4250-b29f-b0d72f1e84c0",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "7b0c6eac-453c-4661-8ce9-cbb067016d61",
+      "display_name": "Secure Pro Smart Lock (Deadbolt)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://lockly.com/products/lockly-secure-pro?variant=19786767368251",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#a8a7aa",
+          "manufacturer_sku": "PGD728WSN",
+          "front_image": {
+            "image_id": "5bb9b5be-cc0a-4b57-88d1-675c07093e9b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5bb9b5be-cc0a-4b57-88d1-675c07093e9b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b0ac8191-eecf-4083-98a3-dee9e80558ad",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e9ca0635-3b1a-44d6-9389-57cd4df70c9d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#585858",
+          "manufacturer_sku": "PGD728WMB",
+          "front_image": {
+            "image_id": "c87a5aff-35ec-45e1-8341-2473ebd8e099",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "a62ba9c8-1680-446d-a980-bc71c86b587e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c87a5aff-35ec-45e1-8341-2473ebd8e099",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a62ba9c8-1680-446d-a980-bc71c86b587e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7ffaf2a7-624e-42e0-8210-8eb5d3b07bfd",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2624d3a3-cc1a-4b0e-a35b-e2e13d167427",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "primary_color_hex": "#262624",
+          "manufacturer_sku": "PGD728WVB",
+          "front_image": {
+            "image_id": "3c10c06e-8583-4a0d-8eff-f2ba260e897c",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "c47b125b-08bb-4a0a-93b3-ddd1bc61b2c8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3c10c06e-8583-4a0d-8eff-f2ba260e897c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c47b125b-08bb-4a0a-93b3-ddd1bc61b2c8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "974ba015-790a-44fa-9675-39d2211e0af0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "520e32cf-fc5a-4bdb-8b8f-11f46abc6434",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "69e8d147-1602-4fee-b5ba-ab2c46741a17",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "06161321-fd33-4fdc-9b81-8ba1a61f0921",
+      "display_name": "Guard Duo (679d)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/679d/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lever",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#2d2d2d",
+          "front_image": {
+            "image_id": "5b583fa4-2538-4964-93b9-473ce7fbca72",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "fdd93eb0-9fb5-422b-a7f1-5ceb0cccf7eb",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5b583fa4-2538-4964-93b9-473ce7fbca72",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "fdd93eb0-9fb5-422b-a7f1-5ceb0cccf7eb",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f68964c2-a13b-43df-9e60-583193788644",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#323232",
+          "front_image": {
+            "image_id": "8128f372-edf1-4551-a08e-e68ee3c1743e",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "ee43ae33-7448-45b7-a0d5-d43eeeba29f7",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8128f372-edf1-4551-a08e-e68ee3c1743e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ee43ae33-7448-45b7-a0d5-d43eeeba29f7",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "3c50a523-fcf9-4d99-baa6-d0f7d9d1ff19",
+      "display_name": "Guard deadbolt (728Z)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://locklypro.com/728z/",
+      "main_connection_type": "unknown",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "ec677c19-0cda-45bf-b50d-ee39e0e940a2",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#afafa6",
+          "front_image": {
+            "image_id": "a7a7c967-bf15-40ec-aef0-0571ff4c6153",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a7a7c967-bf15-40ec-aef0-0571ff4c6153",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ee988f6c-cc98-4b04-9967-0b976f835201",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0d8dbd0b-2e9d-43b0-bbe8-906566dda289",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "66ae0d4f-87cb-4d4d-89ca-954323cbd4c7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9cf9c6d7-cfe8-4b33-8a84-9f9b7820a5fc",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "venetian_bronze",
+          "display_name": "Venetian Bronze",
+          "images": []
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#4c4c4c",
+          "front_image": {
+            "image_id": "5d438b1a-2a7b-494e-a32b-3933a0d37932",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "2996b589-eedb-4e97-aad5-30e119d2c8be",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5d438b1a-2a7b-494e-a32b-3933a0d37932",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "2996b589-eedb-4e97-aad5-30e119d2c8be",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ae9f8c2a-02e6-4743-a754-93963230d57f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6ff760d0-b310-4af6-9467-442dece73a3f",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "57ede183-ff77-42c7-b622-851c3f54cf0c",
+      "display_name": "Wi-Fi Smart Lock",
+      "description": "The all-in-one Wi-Fi Smart Lock has all the convenience and intelligence you need in two colors: matte black and silver. It comes equipped with built-in Wi-Fi and smart features like remote access and auto-lock. In addition to being able to use your existing keys to lock and unlock the door, you can also use your smartphone or Apple Watch and the August App for added convenience.",
+      "is_device_supported": true,
+      "product_url": "https://august.com/products/august-wifi-smart-lock?view=wifi-smart-lock-2",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "cfe546ca-7a99-48e0-a665-4304dca85b4e",
+      "aesthetic_variants": [
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#353537",
+          "manufacturer_sku": "AUG-SL05-M01-G01",
+          "front_image": {
+            "image_id": "4057b6c3-e3a7-49b6-9545-2e40e3fd0aa3",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "4057b6c3-e3a7-49b6-9545-2e40e3fd0aa3",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "de448af6-7041-462d-9112-94707f967eec",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "37ebe5c4-7a96-44b7-a215-8ff1817fbd2c",
+              "width": 1000,
+              "height": 1000
+            }
+          ]
+        },
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#c7c8cc",
+          "manufacturer_sku": "AUG-SL05-M01-S01",
+          "front_image": {
+            "image_id": "b9f6bd04-44d4-4709-8403-79bfcaad9c86",
+            "width": 1000,
+            "height": 1000
+          },
+          "images": [
+            {
+              "image_id": "b9f6bd04-44d4-4709-8403-79bfcaad9c86",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "0289ccb3-ee86-42f1-b246-70e42e7b1612",
+              "width": 1000,
+              "height": 1000
+            },
+            {
+              "image_id": "5ab46d13-5991-492e-ad43-e6251526c897",
+              "width": 1000,
+              "height": 1000
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "a939848d-9d6b-412d-9f93-b5890b328afc",
+      "display_name": "Smart Lock 2nd Generation",
+      "description": "The August 2nd Generation Smart Lock comes in two colors; silver and dark gray, and allows you to access your home using Amazon Alexa, Apple HomeKit, or your smartphone. It automatically unlocks your door as you approach and automatically locks it after you enter. It also has a 24/7 activity log that lets you know who has accessed your door and when, and is designed to be installed quickly by replacing only the interior of your existing deadbolt.",
+      "is_device_supported": true,
+      "product_url": "",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "cfe546ca-7a99-48e0-a665-4304dca85b4e",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#d2d2d4",
+          "manufacturer_sku": "AUG-SL02-M02-S02-C",
+          "front_image": {
+            "image_id": "ef445d7d-be66-44bf-91c4-dbfb30f3711f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "ef445d7d-be66-44bf-91c4-dbfb30f3711f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "df9a8229-b47a-49a4-b23c-67a5ee3798c4",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "dark_gray",
+          "display_name": "Dark Gray",
+          "primary_color_hex": "#464447",
+          "manufacturer_sku": "AUG-SL02-M02-G02",
+          "front_image": {
+            "image_id": "14eac5db-8907-44ad-96cb-4a21e4733b34",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "14eac5db-8907-44ad-96cb-4a21e4733b34",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "76368b75-a791-48f8-a8f2-705c2d7db9f2",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5d00ec94-f8d7-4dc4-b2bd-1ef015ba0d33",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "700f5131-ce1e-4481-9a0d-9235bb2754aa",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "58a6b9a0-0274-4aee-b159-112a736d0b96",
+      "display_name": "Smart Lock 4th Generation",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://august.com/products/august-wifi-smart-lock",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "cfe546ca-7a99-48e0-a665-4304dca85b4e",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#c9cbcf",
+          "manufacturer_sku": "AUG-SL05-M01-S01",
+          "front_image": {
+            "image_id": "6b8d37fc-5a31-4988-82c2-62b8f62e4103",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6b8d37fc-5a31-4988-82c2-62b8f62e4103",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0d28c00f-6bef-4ee6-9cdd-a83e6d20b5e2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "matte_black",
+          "display_name": "Matte Black",
+          "primary_color_hex": "#343436",
+          "manufacturer_sku": "AUG-SL05-M01-G01",
+          "front_image": {
+            "image_id": "2beb6c23-4207-4b2e-8201-61d96768eecf",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "2beb6c23-4207-4b2e-8201-61d96768eecf",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6ab14f86-25a8-4ec2-92a3-89aff8e2cc4d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "5765ed5e-a2fa-4673-9ee4-7a5825329030",
+      "display_name": "Smart Lock 1st Generation",
+      "description": "August’s first smart lock offering comes in champagne and silver colors and provides secure keyless access to your home using iOS and Android smartphones. It is easy to install as a DIY retrofit, replacing the interior of your existing deadbolt while leaving the outside unchanged, and allows you total control over who has access to your home and can manage how long their access lasts. Additionally, the product is powered by batteries, ensuring that it is always on, even if your power, Wi-Fi, or cable go down.",
+      "is_device_supported": true,
+      "product_url": "",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "cfe546ca-7a99-48e0-a665-4304dca85b4e",
+      "aesthetic_variants": [
+        {
+          "slug": "champagne",
+          "display_name": "Champagne",
+          "primary_color_hex": "#a99182",
+          "manufacturer_sku": "AUG-SL01-M01-C01",
+          "front_image": {
+            "image_id": "76565793-8f5a-47f1-819b-19c4f662e483",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "76565793-8f5a-47f1-819b-19c4f662e483",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "dark_gray",
+          "display_name": "Dark Gray",
+          "primary_color_hex": "#424242",
+          "manufacturer_sku": "AUG-SL01-M01-G01",
+          "front_image": {
+            "image_id": "6c7429d1-13ca-4ea3-8ad8-f156b499b3b6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6c7429d1-13ca-4ea3-8ad8-f156b499b3b6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#bfbfbf",
+          "manufacturer_sku": "AUG-SL01-M01-S01",
+          "front_image": {
+            "image_id": "12bf0c04-d6e7-44c3-99f5-6a933413474e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "12bf0c04-d6e7-44c3-99f5-6a933413474e",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "3d2605ce-4ed8-4de7-8c86-4a44c4dcd5d9",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "b89e7e9a-1ba3-46ba-b05b-b20ec3133898",
+      "display_name": "Smart Lock 3rd Generation",
+      "description": "The August Smart Lock 3rd Generation allows you to remotely lock and unlock your door, and also allows you to provide secure digital keys to guests using your phone. It easily attaches to an existing deadbolt on the inside of your door, allowing you to continue using your physical keys. It can be controlled using voice commands with Amazon Alexa or Google Assistant, and comes in three colors: Silver, Satin Nickel, and Dark Gray.",
+      "is_device_supported": true,
+      "product_url": "https://august.com/products/august-smart-lock-3rd-generation",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "cfe546ca-7a99-48e0-a665-4304dca85b4e",
+      "aesthetic_variants": [
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#c6c7cb",
+          "manufacturer_sku": "AUG-SL04-M01-S04",
+          "front_image": {
+            "image_id": "861dcf47-9afa-401a-8072-148883f778a7",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "a9f7b674-106c-414f-9cbe-ee72d99f8bf8",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "861dcf47-9afa-401a-8072-148883f778a7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e0a7f614-f148-4d69-9c4c-4959b255f18b",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a9f7b674-106c-414f-9cbe-ee72d99f8bf8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e41dccb9-bfd7-41f7-a77d-8b167116b113",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4bd22231-d2c9-4102-af1b-ddfebcb2e41a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ebc8fa71-8901-4dc2-a3be-0317211f1745",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "dark_gray",
+          "display_name": "Dark Gray",
+          "primary_color_hex": "#363435",
+          "manufacturer_sku": "AUG-SL04-M01-G04",
+          "front_image": {
+            "image_id": "f9944a70-c957-4682-a9fc-002d371b35b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "f9944a70-c957-4682-a9fc-002d371b35b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "0e3b01f3-0200-493f-852e-ee431c5b16d2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "satin_nickel",
+          "display_name": "Satin Nickel",
+          "primary_color_hex": "#a7a3a2",
+          "manufacturer_sku": "AUG-SL04-C03-N04",
+          "front_image": {
+            "image_id": "dac7e7aa-0263-4f06-a3d6-03df01a5050a",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dac7e7aa-0263-4f06-a3d6-03df01a5050a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "19415a64-5141-4451-8143-b25cd6906ced",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4489946b-570f-4fd3-8ae8-6d0a3d4d18b6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "23baf3d3-5805-4ebc-8ec1-220aebf03984",
+      "display_name": "Smart Lock Pro",
+      "description": "Gorgeously designed by Fuse Project, the August Wi-Fi Smart Lock Pro offers a range of convenient and intelligent features such as access codes (requires pin pad accessory), unlock anywhere, monitor logs, battery level, and more. It comes with built-in wifi and lets you use your existing keys. The August App lets you unlock from anywhere and can be unlocked with your Apple Watch.",
+      "is_device_supported": true,
+      "product_url": "",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "cfe546ca-7a99-48e0-a665-4304dca85b4e",
+      "aesthetic_variants": [
+        {
+          "slug": "dark_gray",
+          "display_name": "Dark Gray",
+          "primary_color_hex": "#444144",
+          "manufacturer_sku": "AUG-SL03-C02-G03",
+          "front_image": {
+            "image_id": "3d26843b-4d7f-48ca-9b62-2320389fa406",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3d26843b-4d7f-48ca-9b62-2320389fa406",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e05fc379-e077-4fce-873d-47aacaff65f0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "71f54486-27f2-4e12-bb6f-3b89a31241ee",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#c3c4c8",
+          "manufacturer_sku": "AUG-SL03-C02-S03",
+          "front_image": {
+            "image_id": "c0c127e1-ebcc-46e5-ac10-ac80f17c1c58",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c0c127e1-ebcc-46e5-ac10-ac80f17c1c58",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "34e98a06-746b-46b8-8668-b0d82707a0b1",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9ace4652-40ca-4dfc-b8e2-de4a5d381bbd",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "a7d7caa3-1784-4ce5-b474-bf6e177e3345",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "3f664822-e33c-4eab-ba30-1c4a6496c344",
+      "display_name": "Smart Lock Pro 3rd Generation",
+      "description": "The August Smart Lock Pro 3rd Generation is available in dark gray and silver and allows you to unlock your home using your voice and a smart assistant such as Alexa, Siri, or Google Assistant. The lock also has a 24/7 activity feed that tracks activity at your doorstep. Additionally, you can keep your existing lock and keys and easily retrofit the smart lock to your existing deadbolt, and the lock will automatically lock behind you and unlock as you approach.",
+      "is_device_supported": true,
+      "product_url": "",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "cfe546ca-7a99-48e0-a665-4304dca85b4e",
+      "aesthetic_variants": [
+        {
+          "slug": "dark_gray",
+          "display_name": "Dark Gray",
+          "primary_color_hex": "#59575a",
+          "manufacturer_sku": "AUG-SL03-M03-G03",
+          "front_image": {
+            "image_id": "d0984ae1-8a11-4ca9-adf0-dc8f115a33f8",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "c5d03966-b00c-4406-ad06-47bc64d599ba",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "d0984ae1-8a11-4ca9-adf0-dc8f115a33f8",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6894a8f2-5255-499a-a153-5a300653a00c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e05fc379-e077-4fce-873d-47aacaff65f0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c5d03966-b00c-4406-ad06-47bc64d599ba",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "silver",
+          "display_name": "Silver",
+          "primary_color_hex": "#939297",
+          "manufacturer_sku": "AUG-SL03-M03-S03",
+          "front_image": {
+            "image_id": "0d0bae71-1a3b-4dd3-9c29-2ec45e5b3b42",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "0d0bae71-1a3b-4dd3-9c29-2ec45e5b3b42",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4cb1c0d5-3159-44a2-a12a-52b0cc399380",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "71fd666d-8eb6-436d-8b67-5928c333a824",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "4025cc3b-ba06-4dc6-9d65-80046f4227ae",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "89d23d02-fa09-45eb-ac51-2ae03790f9c9",
+      "display_name": "XS4 Original+ EURO",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en-in/products/xs4-original-plus-eu/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#bfbfbf",
+          "front_image": {
+            "image_id": "3dd6a89a-60d3-4623-8ce6-534f5c4045f7",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3dd6a89a-60d3-4623-8ce6-534f5c4045f7",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "9ab7131d-e317-4964-bf6f-614a3e89feb8",
+      "display_name": "Ælement Fusion - EU / DIN",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/aelement-fusion-eu-din/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#b4aaa4",
+          "front_image": {
+            "image_id": "dd9a3bda-f190-4562-b472-9c44db51c07e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dd9a3bda-f190-4562-b472-9c44db51c07e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "5caf51e8-f9d8-4c22-9a49-45f7e985390d",
+      "display_name": "Neo Cylinder - ANSI",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-deadbolt-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#cfcfcf",
+          "front_image": {
+            "image_id": "21d1285a-1e47-40bb-b628-215afdec1ddd",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "21d1285a-1e47-40bb-b628-215afdec1ddd",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "6fec5d1e-1b6d-4975-bc32-9ea22659a700",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "e7acce26-4d56-4767-8698-c89e53a8dfff",
+      "display_name": "XS4 One - DIN",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-one-din/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#dedede",
+          "front_image": {
+            "image_id": "c3a9c372-9a48-4cbd-bad8-9abb02f57747",
+            "width": 1100,
+            "height": 1100
+          },
+          "back_image": {
+            "image_id": "5802015e-c851-4639-aca2-a6fb49d9d851",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "c3a9c372-9a48-4cbd-bad8-9abb02f57747",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5802015e-c851-4639-aca2-a6fb49d9d851",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "84422876-228a-4221-a930-23ce2281e3dc",
+      "display_name": "XS4 Original - ANSI",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en-us/products/electronic-locks/xs4-original-ansi/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#a4a9b2",
+          "front_image": {
+            "image_id": "62e6a8ec-7468-474a-bbdc-7daa7be9188c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "62e6a8ec-7468-474a-bbdc-7daa7be9188c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "1429b8fb-384b-4d94-b7a1-56d8b688945d",
+      "display_name": "Neo Cylinder - UK (Oval)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-uk-oval-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e6787f58-4738-49cb-9099-9b23a9eee939",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "b514dee0-e8eb-426b-848b-b11c0b1933f6",
+      "display_name": "XS4 Original Keypad - EU",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en-in/products/xs4-original-keypad-eu/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#525357",
+          "front_image": {
+            "image_id": "b32d2666-3034-483a-941d-212291cdcd18",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b32d2666-3034-483a-941d-212291cdcd18",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "edb19bb1-1870-4ccc-8da8-b3db445bf3e9",
+      "display_name": "XS4 Mini - Finnish",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-mini-finnish/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#dddddf",
+          "front_image": {
+            "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7ef7ae20-322e-4fa5-b90c-9ec98cc0fcd1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#2c2c2c",
+          "front_image": {
+            "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7ef7ae20-322e-4fa5-b90c-9ec98cc0fcd1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "5a0afa57-d592-4cd9-aac5-216eff64260c",
+      "display_name": "XS4 Mini - Scandinavian",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-mini-scandinavian/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#dddddf",
+          "front_image": {
+            "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7ef7ae20-322e-4fa5-b90c-9ec98cc0fcd1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#2c2c2c",
+          "front_image": {
+            "image_id": "5bf24422-0d30-4c48-9c87-4ba9ab244530",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5bf24422-0d30-4c48-9c87-4ba9ab244530",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "24bd8f85-daa8-40e3-9be5-f1ef5bf9c987",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "94bd286c-2bd9-4e8e-9862-57c5a63452c3",
+      "display_name": "Ælement Fusion - ANSI",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/aelement-fusion-ansi/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#b4aaa4",
+          "front_image": {
+            "image_id": "dd9a3bda-f190-4562-b472-9c44db51c07e",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "dd9a3bda-f190-4562-b472-9c44db51c07e",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "1f5064bc-fb14-4fe7-89e2-bf586bc4e1d1",
+      "display_name": "Neo Cylinder - Australian",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-australian-oval-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "29ce6562-1bf6-4e07-8bc9-29370cfa1713",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6d5ba6dd-2a45-48c7-9328-72bb9b6ca605",
+      "display_name": "Neo Cylinder - Swing Handle",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-swing-handle-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#323232",
+          "front_image": {
+            "image_id": "b0477c9b-86e5-4a36-b8f0-67be03fd832f",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b0477c9b-86e5-4a36-b8f0-67be03fd832f",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "28743fac-18cb-4bc6-a66b-fd95af2e45e5",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "efeeb1e1-ba9b-4c8a-b045-e4ca6c80e2b8",
+      "display_name": "XS4 Mini - European / DIN",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-mini-european-din/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#dddddf",
+          "front_image": {
+            "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7ef7ae20-322e-4fa5-b90c-9ec98cc0fcd1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#2c2c2c",
+          "front_image": {
+            "image_id": "5bf24422-0d30-4c48-9c87-4ba9ab244530",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5bf24422-0d30-4c48-9c87-4ba9ab244530",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "24bd8f85-daa8-40e3-9be5-f1ef5bf9c987",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "79786908-f43e-4724-8535-92cf92090585",
+      "display_name": "XS4 Original+ Wide EURO",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-original-wide-plus-eu/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#545559",
+          "front_image": {
+            "image_id": "a36caa85-5549-45c9-8c04-9f27d008750d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "a36caa85-5549-45c9-8c04-9f27d008750d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "2275273d-fd9c-4bc9-a0e2-b9a4a41e2d3d",
+      "display_name": "XS4 Original+ Scandinavian",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-original-plus-scandinavian/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#575757",
+          "front_image": {
+            "image_id": "b72a4f7b-3497-4d72-ba92-ce9ab1418c8c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b72a4f7b-3497-4d72-ba92-ce9ab1418c8c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "31e8795c-02cf-467d-867d-c88f2650b518",
+      "display_name": "XS4 One - EU",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/electronic-locks/xs4-one/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#d1c9c7",
+          "front_image": {
+            "image_id": "eed873fe-75fe-4cf1-9fb6-d4edad6ceca7",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "eed873fe-75fe-4cf1-9fb6-d4edad6ceca7",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ac4b0313-dff8-4f47-bda7-4720227ef422",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "87b93408-1a5a-40c9-9d18-98fae578242c",
+      "display_name": "Neoxx Padlock - G4",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neoxx-padlock-g4/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "padlock",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#525254",
+          "front_image": {
+            "image_id": "f64af351-1975-4fcd-a0c6-59459b6d8b13",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "f64af351-1975-4fcd-a0c6-59459b6d8b13",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "1b83f73f-1d09-4257-ba5a-da17f0c92fd9",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "710d428c-ba40-4cb3-a68d-8dd94a06c067",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "52a5c6c3-b7bb-47ed-9aaa-8ad8c90b92e4",
+      "display_name": "Neo Cylinder - European",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-european-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "17fc80ce-cee4-400a-9a9e-3e326ff47bbf",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "9f5f4575-1538-4ff4-b4f5-7e9ced8ddb62",
+      "display_name": "XS4 Original+ Wide Scandinavian",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-original-plus-wide-scandinavian/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#dfdfdf",
+          "front_image": {
+            "image_id": "27b5b838-08e2-4e98-aed9-42f276176cb6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "27b5b838-08e2-4e98-aed9-42f276176cb6",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "e3c526eb-4858-40d7-9fd6-fdfe18dbea2d",
+      "display_name": "XS4 Locker Lock",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en-in/products/xs4-locker-locks/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "locker",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#343434",
+          "front_image": {
+            "image_id": "55df78a6-206e-47b6-a282-de7170c69a67",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "55df78a6-206e-47b6-a282-de7170c69a67",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#c1c1c1",
+          "front_image": {
+            "image_id": "50001fd0-a2c3-4681-8194-90898ba44438",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "50001fd0-a2c3-4681-8194-90898ba44438",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "90da303f-5dc1-4846-bbbe-bf6b5e7d0178",
+      "display_name": "Neo Cylinder - US (Rim)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-rim-us-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "c0a396a8-8349-4ca9-ad38-50568becd8be",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "a90cdc21-1a3c-4de8-93c6-82c25334e3ad",
+      "display_name": "XS4 Original+ DIN",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-original-plus-din_satin-stainless-steel/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#c8c6c7",
+          "front_image": {
+            "image_id": "b492bee0-7b04-4fc4-92e1-f35b37872b35",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b492bee0-7b04-4fc4-92e1-f35b37872b35",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b698bb58-554c-4b24-b6d8-4db9ead98374",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b132cbd2-33da-4806-bc33-a9273586faaa",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "e7b44c00-38f4-4149-ad39-075079246bf1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "7fcbe195-1021-429e-b87b-4b46271592f5",
+      "display_name": "Design XS - ANSI Keypad Wall Reader",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/design-xs-ansi-keypad-wall-reader/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "hardwired"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "lockbox",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#101010",
+          "manufacturer_sku": "SAL-WRDG0A4BK",
+          "front_image": {
+            "image_id": "18ce1e24-a590-4e55-835e-917e80628dc6",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "18ce1e24-a590-4e55-835e-917e80628dc6",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "9dcc15f4-35ac-456c-bf9e-7a7aa47ee4ba",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#c8cac9",
+          "manufacturer_sku": "SAL-WRDG0A4WK",
+          "front_image": {
+            "image_id": "11aab207-97f2-431e-91b0-6e74f421bc4c",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "11aab207-97f2-431e-91b0-6e74f421bc4c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "5c2f20af-64b7-480b-bfe1-1ef41ace7652",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6ec64436-614b-4c3b-8d10-1009200cf6d7",
+      "display_name": "Neo Cylinder - Swiss",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-swiss-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "afbd2dc8-ac94-4a1c-ad4f-14f62c42a345",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "a0a32284-b208-4a7d-a4db-892b779608df",
+      "display_name": "Neo Cylinder - CAM",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-cam-lock-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "253ab566-2c52-479c-b857-c971dd5cafb9",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "bbd4b788-c2b8-47a0-8083-058acb33e6c9",
+      "display_name": "Neo Cylinder",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/electronic-cylinders/neo-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "b0da72e9-5693-473f-b77c-c6e1bd842e52",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "27dbef9f-3541-45b9-b740-97034f84bc0a",
+      "display_name": "XS4 Mini - Australia",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-mini-australia/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#dddddf",
+          "front_image": {
+            "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "fb40581a-3677-44b1-b571-4dfa196e06e0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "7ef7ae20-322e-4fa5-b90c-9ec98cc0fcd1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#2c2c2c",
+          "front_image": {
+            "image_id": "5bf24422-0d30-4c48-9c87-4ba9ab244530",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "5bf24422-0d30-4c48-9c87-4ba9ab244530",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "24bd8f85-daa8-40e3-9be5-f1ef5bf9c987",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "d5f58704-0165-4a95-a647-84d3fa46c5a4",
+      "display_name": "Neo Cylinder - Scandinavian Oval Cylinder",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-scandinavian-oval-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "eaf51145-9c12-4595-8024-5633db28630c",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f82383ce-23ee-4b56-b89f-b759f359b80d",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "d0af0c81-8e2e-4d89-b4ae-43651e2a46f7",
+      "display_name": "XS4 One - Deadlatch",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-one-deadlatch/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#323232",
+          "front_image": {
+            "image_id": "94255dad-7c6b-4519-8d2e-f24f6e4f7b28",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "94255dad-7c6b-4519-8d2e-f24f6e4f7b28",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "dda5df75-c773-4cde-83b5-991004699fa1",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "344afb2a-32cb-4fbc-a23e-70539d69ad75",
+      "display_name": "XS4 Original Keypad - Scandinavian",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-original-keypad-scandinavian/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#8d9399",
+          "front_image": {
+            "image_id": "3625fb16-f329-4db5-9307-d2a413701b13",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "3625fb16-f329-4db5-9307-d2a413701b13",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "71281671-0b76-4ee2-98ae-2f96e8ae9e18",
+      "display_name": "XS4 Glass Door - DIN",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-glass-door-din/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#d5d4d2",
+          "front_image": {
+            "image_id": "1747a877-4548-400e-b321-226375058c5b",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "1747a877-4548-400e-b321-226375058c5b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "462a88d7-436e-4281-b6b0-268edcc9e64f",
+      "display_name": "Neo Cylinder - Scandinavian Security",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-scandinavian-security-cylinder",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "73fb81de-221d-4d5a-afa0-e0d3ebeb3b5b",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "88eaad55-ad84-421f-877a-48e6a14b1df9",
+      "display_name": "Neo Cylinder - Mortise",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-mortise-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "f579fef3-ff8b-452a-8be9-c63904f0e3bd",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "738420bb-d5a6-4502-a768-f593549f6bc8",
+      "display_name": "Neo Cylinder - UK (Rim)",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neo-rim-uk-cylinder/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "cylinder",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#e8e8e8",
+          "front_image": {
+            "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "b3a4dc1b-caea-40cf-b6ef-caafbdd73fd2",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#313133",
+          "front_image": {
+            "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "8930b5b8-d350-4e35-bad6-74b77ae6f2b0",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "507c9e71-5526-4cfb-8b9b-0301e14eaa0c",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "ae5ea45a-ee99-49fd-999c-9b699fa18945",
+      "display_name": "XS4 Mini - ANSI",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/xs4-mini-ansi/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#dddddd",
+          "front_image": {
+            "image_id": "10189a76-7d2e-48bc-921e-5cf7162ae69a",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "10189a76-7d2e-48bc-921e-5cf7162ae69a",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#ededed",
+          "front_image": {
+            "image_id": "f61e5a94-ba17-4a21-a6bb-16c5880ebb58",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "f61e5a94-ba17-4a21-a6bb-16c5880ebb58",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "3b41cc19-9d0e-4fd7-9ea3-05814cf0af53",
+      "display_name": "Neoxx Padlock - G3",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en/products/salto-neoxx-padlock-g3/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "padlock",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": false,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#28292d",
+          "front_image": {
+            "image_id": "14b5121e-f62a-4763-9bb4-be7c4bc97c9a",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "14b5121e-f62a-4763-9bb4-be7c4bc97c9a",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "10179f65-a666-4391-8554-ac95747d6a49",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "6fd92ae1-18d7-456e-94d8-ae5a1718a53d",
+      "display_name": "XS4 Original Keypad - ANSI",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://saltosystems.com/en-in/products/xs4-original-keypad-ansi/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "mortise",
+        "has_physical_key": false,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": true
+      },
+      "manufacturer_id": "5b4d97f6-5734-4537-9730-3392a0b0542e",
+      "aesthetic_variants": [
+        {
+          "slug": "satin_stainless_steel",
+          "display_name": "Satin Stainless Steel",
+          "primary_color_hex": "#535559",
+          "front_image": {
+            "image_id": "e66131fb-f40e-42bf-8926-93cd8d50df74",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "e66131fb-f40e-42bf-8926-93cd8d50df74",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "07b78911-da52-4644-9d0b-d389828730ea",
+      "display_name": "SMART LOCK 2.0",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://www.amazon.ae/NUKi-Home-Solutions-Smart-220113/dp/B07F1PGYBW",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ed3ef2c0-5e2b-452a-ab9d-eb3aa9a9eada",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#191919",
+          "front_image": {
+            "image_id": "57f82113-e685-4a2d-92d8-c84b50f06072",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "57f82113-e685-4a2d-92d8-c84b50f06072",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "ec7e7193-14a7-4ab4-8ead-da3307f1d1d7",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "5c62db8c-1d8a-46d8-b80e-09de9ccd1b08",
+      "display_name": "SMART LOCK 3.0 PRO",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://nuki.io/en/smart-lock-pro/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ed3ef2c0-5e2b-452a-ab9d-eb3aa9a9eada",
+      "aesthetic_variants": [
+        {
+          "slug": "black",
+          "display_name": "Black",
+          "primary_color_hex": "#1c1c1c",
+          "front_image": {
+            "image_id": "6335f3ec-a799-4060-a446-562765f5ab9d",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "6335f3ec-a799-4060-a446-562765f5ab9d",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "8b7ab146-782f-4bbb-892d-e37d5c2b1ebc",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        },
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#f6f6f6",
+          "front_image": {
+            "image_id": "9c750155-4382-4dcb-8b2d-c83ba58b4c58",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "9c750155-4382-4dcb-8b2d-c83ba58b4c58",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "47374401-1bef-4cb3-9815-cd195f14f2dd",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "device_model_id": "288390b0-8d7d-4691-bdd5-8befc185b7a1",
+      "display_name": "SMART LOCK 3.0",
+      "description": "",
+      "is_device_supported": true,
+      "product_url": "https://nuki.io/en/smart-lock/",
+      "main_connection_type": "wifi",
+      "power_sources": [
+        "battery"
+      ],
+      "main_category": "smartlock",
+      "physical_properties": {
+        "lock_type": "deadbolt",
+        "has_physical_key": true,
+        "has_camera": false
+      },
+      "software_features": {
+        "can_remotely_unlock": true,
+        "can_program_access_codes": true,
+        "can_program_access_schedules": true,
+        "can_program_access_codes_offline": false
+      },
+      "manufacturer_id": "ed3ef2c0-5e2b-452a-ab9d-eb3aa9a9eada",
+      "aesthetic_variants": [
+        {
+          "slug": "white",
+          "display_name": "White",
+          "primary_color_hex": "#f5f5f5",
+          "front_image": {
+            "image_id": "05c97a00-5083-48cf-b852-66bab1a3f811",
+            "width": 1100,
+            "height": 1100
+          },
+          "images": [
+            {
+              "image_id": "05c97a00-5083-48cf-b852-66bab1a3f811",
+              "width": 1100,
+              "height": 1100
+            },
+            {
+              "image_id": "84ad9af6-a9ee-4e38-b475-b4f6eed880d3",
+              "width": 1100,
+              "height": 1100
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "vercel_protection_bypass_secret": "abc123",
+  "external_image_proxy_endpoint": "https://connect.getseam.com/internal/devicedb_image_proxy"
+}

--- a/.storybook/middleware.js
+++ b/.storybook/middleware.js
@@ -1,3 +1,6 @@
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+
 import { createProxyMiddleware } from 'http-proxy-middleware'
 
 import { seedFake } from './seed-fake.js'
@@ -9,6 +12,16 @@ export default async (app) => {
   const { createFake } = await import('@seamapi/fake-seam-connect')
   const fake = await createFake()
   seedFake(fake.database)
+
+  const fakeDevicedb = await getFakeDevicedb()
+  const fakeDevicedbUrl = fakeDevicedb.serverUrl
+  if (fakeDevicedbUrl == null) throw new Error('Missing fake devicedb url')
+  fake.database.setDevicedbConfig({
+    url: fakeDevicedbUrl,
+    vercelProtectionBypassSecret:
+      fakeDevicedb.database.vercel_protection_bypass_secret,
+  })
+
   await fake.startServer()
 
   // eslint-disable-next-line no-console
@@ -29,4 +42,19 @@ export default async (app) => {
       target: 'http://localhost:8080',
     })
   )
+}
+
+const getFakeDevicedb = async () => {
+  const { createFake } = await import('@seamapi/fake-devicedb')
+  const seed = await readFile(
+    fileURLToPath(new URL('devicedb-seed.json', import.meta.url))
+  )
+  const fake = await createFake()
+  await fake.loadJSON(JSON.parse(seed.toString()))
+  await fake.startServer()
+
+  // eslint-disable-next-line no-console
+  console.log(`Fake Devicedb server running at: "${fake.serverUrl}"`)
+
+  return fake
 }

--- a/.storybook/update-devicedb-seed.ts
+++ b/.storybook/update-devicedb-seed.ts
@@ -1,0 +1,44 @@
+import { fileURLToPath } from 'node:url'
+
+import {
+  createFake,
+  type Database,
+  seedDatabaseFromApi,
+} from '@seamapi/fake-devicedb'
+import { SeamHttp } from '@seamapi/http/connect'
+import { writeFile } from 'fs/promises'
+
+const main = async (): Promise<void> => {
+  const publishableKey = 'seam_pk1J0Bgui_oYEuzDhOqUzSBkrPmrNsUuKL'
+  const userIdentifierKey = ' 7ff81ed1-51d4-4e77-9c8d-6f2b8ff8fc35'
+
+  const fake = await createFake()
+  await seedDatabase(fake.database, publishableKey, userIdentifierKey)
+
+  const json = await fake.toJSON()
+
+  await writeFile(
+    fileURLToPath(new URL('devicedb-seed.json', import.meta.url)),
+    JSON.stringify(json, null, 2)
+  )
+}
+
+const seedDatabase = async (
+  db: Database,
+  publishableKey: string,
+  userIdentifierKey: string
+): Promise<void> => {
+  const seam = await SeamHttp.fromPublishableKey(
+    publishableKey,
+    userIdentifierKey
+  )
+  const baseURL = seam.client.defaults.baseURL
+  seam.client.defaults.baseURL = new URL(
+    '/internal/devicedb',
+    baseURL
+  ).toString()
+
+  await seedDatabaseFromApi(db, seam.client)
+}
+
+await main()

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "luxon": "^3.3.0",
         "queue": "^7.0.0",
         "react-hook-form": "^7.46.1",
-        "seamapi": "^8.13.0",
+        "seamapi": "^8.13.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -22,7 +22,9 @@
         "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.12.2",
         "@rxfork/r2wc-react-to-web-component": "^2.4.0",
+        "@seamapi/fake-devicedb": "^1.0.0-rc.0",
         "@seamapi/fake-seam-connect": "^1.30.0",
+        "@seamapi/http": "^0.2.1",
         "@seamapi/types": "^1.26.2",
         "@storybook/addon-designs": "^7.0.1",
         "@storybook/addon-essentials": "^7.0.2",
@@ -4509,7 +4511,6 @@
       "resolved": "https://registry.npmjs.org/@seamapi/fake-devicedb/-/fake-devicedb-1.0.0-rc.0.tgz",
       "integrity": "sha512-jNOVOMQddkwpq6NYHG85V0/crtzv3codmhefIbATuJ6aJJVmpNly0GIUrpu9zSP/A6ot9KiQBmkhIWlAHFCdWQ==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=16.13.0",
         "npm": ">= 8.1.0"
@@ -4536,6 +4537,42 @@
         "@seamapi/fake-devicedb": ">=1.0.0-rc.0",
         "zustand": "^4.3.7",
         "zustand-hoist": "^1.0.0"
+      }
+    },
+    "node_modules/@seamapi/http": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@seamapi/http/-/http-0.2.1.tgz",
+      "integrity": "sha512-rPwlBfog/esf4TTcdr0pj8zu91SpuKgU+DbjJOX4MdX1qdpLT+BlB5zT4/apEgpnKaIDezcA54e2k+kaYYrIwA==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.5.0",
+        "axios-retry": "^3.8.0"
+      },
+      "engines": {
+        "node": ">=16.13.0",
+        "npm": ">= 8.1.0"
+      },
+      "peerDependencies": {
+        "@seamapi/types": "^1.0.0",
+        "type-fest": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@seamapi/types": {
+          "optional": true
+        },
+        "type-fest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@seamapi/http/node_modules/axios-retry": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.8.0.tgz",
+      "integrity": "sha512-CfIsQyWNc5/AE7x/UEReRUadiBmQeoBpSEC+4QyGLJMswTsP1tz0GW2YYPnE7w9+ESMef5zOgLDFpHynNyEZ1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/@seamapi/types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@mui/material": "^5.12.2",
         "@rxfork/r2wc-react-to-web-component": "^2.4.0",
         "@seamapi/fake-seam-connect": "^1.30.0",
+        "@seamapi/types": "^1.26.2",
         "@storybook/addon-designs": "^7.0.1",
         "@storybook/addon-essentials": "^7.0.2",
         "@storybook/addon-links": "^7.0.2",
@@ -80,12 +81,16 @@
         "npm": ">= 8.1.0"
       },
       "peerDependencies": {
+        "@seamapi/types": "^1.26.2",
         "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
+        "@seamapi/types": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         },
@@ -4533,6 +4538,25 @@
         "zustand-hoist": "^1.0.0"
       }
     },
+    "node_modules/@seamapi/types": {
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@seamapi/types/-/types-1.26.2.tgz",
+      "integrity": "sha512-1J9bvF+w9fpFmBvA9viMyZ2ik+fiNThLKEkN7IeF1C/yuAilkiHAxcrbd7//KItojjOe376dbzf39VXHk4FPJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0",
+        "npm": ">= 8.1.0"
+      },
+      "peerDependencies": {
+        "type-fest": "^4.3.1",
+        "zod": "^3.21.4"
+      },
+      "peerDependenciesMeta": {
+        "type-fest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -6028,6 +6052,18 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/csf/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@storybook/docs-mdx": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@storybook/docs-mdx/-/docs-mdx-0.1.0.tgz",
@@ -6400,6 +6436,18 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.58.tgz",
       "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==",
       "dev": true
+    },
+    "node_modules/@storybook/react/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@storybook/router": {
       "version": "7.4.6",
@@ -20737,12 +20785,14 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.4.0.tgz",
+      "integrity": "sha512-HT3RRs7sTfY22KuPQJkD/XjbTbxgP2Je5HPt6H6JEGvcjHd5Lqru75EbrP3tb4FYjNJ+DjLp+MNQTFQU0mhXNw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "engines": {
-        "node": ">=12.20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -22203,7 +22253,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "dev": true,
-      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -107,12 +107,16 @@
     "npm": ">= 8.1.0"
   },
   "peerDependencies": {
+    "@seamapi/types": "^1.26.2",
     "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "peerDependenciesMeta": {
+    "@seamapi/types": {
+      "optional": true
+    },
     "@types/react": {
       "optional": true
     },
@@ -135,6 +139,7 @@
     "@mui/material": "^5.12.2",
     "@rxfork/r2wc-react-to-web-component": "^2.4.0",
     "@seamapi/fake-seam-connect": "^1.30.0",
+    "@seamapi/types": "^1.26.2",
     "@storybook/addon-designs": "^7.0.1",
     "@storybook/addon-essentials": "^7.0.2",
     "@storybook/addon-links": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "storybook:docs": "storybook dev --docs --port 6007",
     "storybook:build": "storybook build",
     "prestorybook:build": "vite build examples",
+    "storybook:update-devicedb-seed": "tsx .storybook/update-devicedb-seed.ts",
     "examples": "vite examples --host",
     "examples:build": "vite build examples",
     "examples:preview": "vite preview examples",
@@ -130,7 +131,7 @@
     "luxon": "^3.3.0",
     "queue": "^7.0.0",
     "react-hook-form": "^7.46.1",
-    "seamapi": "^8.13.0",
+    "seamapi": "^8.13.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
@@ -138,7 +139,9 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.12.2",
     "@rxfork/r2wc-react-to-web-component": "^2.4.0",
+    "@seamapi/fake-devicedb": "^1.0.0-rc.0",
     "@seamapi/fake-seam-connect": "^1.30.0",
+    "@seamapi/http": "^0.2.1",
     "@seamapi/types": "^1.26.2",
     "@storybook/addon-designs": "^7.0.1",
     "@storybook/addon-essentials": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "storybook:build": "storybook build",
     "prestorybook:build": "vite build examples",
     "storybook:update-devicedb-seed": "tsx .storybook/update-devicedb-seed.ts",
+    "poststorybook:update-devicedb-seed": "npm run format",
     "examples": "vite examples --host",
     "examples:build": "vite build examples",
     "examples:preview": "vite preview examples",

--- a/src/lib/seam/components/SupportedDeviceTable/use-device-model.ts
+++ b/src/lib/seam/components/SupportedDeviceTable/use-device-model.ts
@@ -1,0 +1,45 @@
+import type {
+  DeviceModelV1,
+  RouteRequestParams,
+  RouteResponse,
+} from '@seamapi/types/devicedb'
+import { useQuery } from '@tanstack/react-query'
+import type { SeamError } from 'seamapi'
+
+import { useSeamClient } from 'lib/seam/use-seam-client.js'
+import type { UseSeamQueryResult } from 'lib/seam/use-seam-query-result.js'
+
+export type UseDeviceModelParams = DeviceModelsGetParams | string
+export type UseDeviceModelData = DeviceModelV1 | null
+
+export function useDeviceModel(
+  params?: UseDeviceModelParams
+): UseSeamQueryResult<'deviceModel', UseDeviceModelData> {
+  const normalizedParams =
+    typeof params === 'string' ? { device_model_id: params } : params
+
+  const { client: seam } = useSeamClient()
+  const { data, ...rest } = useQuery<
+    DeviceModelsGetResponse['device_model'] | null,
+    SeamError
+  >({
+    enabled: seam != null,
+    queryKey: ['internal', 'device_models', 'get', normalizedParams],
+    queryFn: async () => {
+      if (seam == null) return null
+      const {
+        data: { device_model: deviceModel },
+      } = await seam.client.get<DeviceModelsGetResponse>(
+        '/internal/devicedb/v1/device_models/get',
+        { params: normalizedParams }
+      )
+      return deviceModel
+    },
+  })
+
+  return { ...rest, deviceModel: data }
+}
+
+type DeviceModelsGetParams = RouteRequestParams<'/v1/device_models/get'>
+
+type DeviceModelsGetResponse = RouteResponse<'/v1/device_models/get'>

--- a/src/lib/seam/components/SupportedDeviceTable/use-device-models.ts
+++ b/src/lib/seam/components/SupportedDeviceTable/use-device-models.ts
@@ -1,0 +1,43 @@
+import type {
+  DeviceModelV1,
+  RouteRequestParams,
+  RouteResponse,
+} from '@seamapi/types/devicedb'
+import { useQuery } from '@tanstack/react-query'
+import type { SeamError } from 'seamapi'
+
+import { useSeamClient } from 'lib/seam/use-seam-client.js'
+import type { UseSeamQueryResult } from 'lib/seam/use-seam-query-result.js'
+
+export type UseDeviceModelsParams = DeviceModelsListParams
+export type UseDeviceModelsData = DeviceModelV1[]
+
+export function useDeviceModels(
+  params?: UseDeviceModelsParams
+): UseSeamQueryResult<'deviceModels', UseDeviceModelsData> {
+  const { client: seam } = useSeamClient()
+
+  const { data, ...rest } = useQuery<
+    DeviceModelsListResponse['device_models'],
+    SeamError
+  >({
+    enabled: seam != null,
+    queryKey: ['internal', 'device_models', 'list', params],
+    queryFn: async () => {
+      if (seam == null) return []
+      const {
+        data: { device_models: deviceModels },
+      } = await seam.client.get<DeviceModelsListResponse>(
+        '/internal/devicedb/v1/device_models/list',
+        { params }
+      )
+      return deviceModels
+    },
+  })
+
+  return { ...rest, deviceModels: data }
+}
+
+type DeviceModelsListParams = RouteRequestParams<'/v1/device_models/list'>
+
+type DeviceModelsListResponse = RouteResponse<'/v1/device_models/list'>

--- a/src/lib/seam/components/SupportedDeviceTable/use-manufacturer.ts
+++ b/src/lib/seam/components/SupportedDeviceTable/use-manufacturer.ts
@@ -1,0 +1,45 @@
+import type {
+  Manufacturer,
+  RouteRequestParams,
+  RouteResponse,
+} from '@seamapi/types/devicedb'
+import { useQuery } from '@tanstack/react-query'
+import type { SeamError } from 'seamapi'
+
+import { useSeamClient } from 'lib/seam/use-seam-client.js'
+import type { UseSeamQueryResult } from 'lib/seam/use-seam-query-result.js'
+
+export type UseManufacturerParams = ManufacturersGetParams | string
+export type UseManufacturerData = Manufacturer | null
+
+export function useManufacturer(
+  params?: UseManufacturerParams
+): UseSeamQueryResult<'manufacturer', UseManufacturerData> {
+  const normalizedParams =
+    typeof params === 'string' ? { manufacturer_id: params } : params
+
+  const { client: seam } = useSeamClient()
+  const { data, ...rest } = useQuery<
+    ManufacturersGetResponse['manufacturer'] | null,
+    SeamError
+  >({
+    enabled: seam != null,
+    queryKey: ['internal', 'manufacturers', 'get', normalizedParams],
+    queryFn: async () => {
+      if (seam == null) return null
+      const {
+        data: { manufacturer },
+      } = await seam.client.get<ManufacturersGetResponse>(
+        '/internal/devicedb/v1/manufacturers/get',
+        { params: normalizedParams }
+      )
+      return manufacturer
+    },
+  })
+
+  return { ...rest, manufacturer: data }
+}
+
+type ManufacturersGetParams = RouteRequestParams<'/v1/manufacturers/get'>
+
+type ManufacturersGetResponse = RouteResponse<'/v1/manufacturers/get'>

--- a/src/lib/seam/components/SupportedDeviceTable/use-manufacturers.ts
+++ b/src/lib/seam/components/SupportedDeviceTable/use-manufacturers.ts
@@ -1,0 +1,43 @@
+import type {
+  Manufacturer,
+  RouteRequestParams,
+  RouteResponse,
+} from '@seamapi/types/devicedb'
+import { useQuery } from '@tanstack/react-query'
+import type { SeamError } from 'seamapi'
+
+import { useSeamClient } from 'lib/seam/use-seam-client.js'
+import type { UseSeamQueryResult } from 'lib/seam/use-seam-query-result.js'
+
+export type UseManufacturersParams = ManufacturersListParams
+export type UseManufacturersData = Manufacturer[]
+
+export function useManufacturers(
+  params?: UseManufacturersParams
+): UseSeamQueryResult<'manufacturers', UseManufacturersData> {
+  const { client: seam } = useSeamClient()
+
+  const { data, ...rest } = useQuery<
+    ManufacturersListResponse['manufacturers'],
+    SeamError
+  >({
+    enabled: seam != null,
+    queryKey: ['internal', 'manufacturers', 'list', params],
+    queryFn: async () => {
+      if (seam == null) return []
+      const {
+        data: { manufacturers },
+      } = await seam.client.get<ManufacturersListResponse>(
+        '/internal/devicedb/v1/manufacturers/list',
+        { params }
+      )
+      return manufacturers
+    },
+  })
+
+  return { ...rest, manufacturers: data }
+}
+
+type ManufacturersListParams = RouteRequestParams<'/v1/manufacturers/list'>
+
+type ManufacturersListResponse = RouteResponse<'/v1/manufacturers/list'>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     "examples/**/*",
     "api/**/*",
     ".storybook/**/*",
+    "update-devicedb-seed.ts",
     "prepack.ts",
     "preversion.ts",
     "version.ts",


### PR DESCRIPTION
Note that this enables local storybook development with the new device db, but it will NOT work yet in the live storybook environments yet (will be handled in follow up PR, testing is over here: https://github.com/seamapi/react/pull/524/commits/8c628ab133029329d7d998ffb71f083ae3a84d0e).
