### PR TITLE
Add automatic visibility behavior to `Snackbar`

### DIFF
--- a/src/lib/ui/Snackbar/Snackbar.tsx
+++ b/src/lib/ui/Snackbar/Snackbar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { CheckGreenIcon } from 'lib/icons/CheckGreen.js'
 import { CloseWhiteIcon } from 'lib/icons/CloseWhite.js'
@@ -19,6 +19,7 @@ interface SnackbarProps {
   autoDismiss?: boolean
   dismissAfterMs?: number
   disableCloseButton?: boolean
+  automaticVisibility?: boolean
 }
 
 export function Snackbar({
@@ -29,9 +30,21 @@ export function Snackbar({
   autoDismiss = false,
   dismissAfterMs = 5000,
   disableCloseButton = false,
+  automaticVisibility = false,
   onClose = () => {},
 }: SnackbarProps): JSX.Element {
+  const [hidden, setHidden] = useState(visible)
+
+  useEffect(() => {
+    setHidden(!visible)
+  }, [visible])
+
   const { label: actionLabel, onClick: handleActionClick } = action ?? {}
+
+  const handleClose = () => {
+    setHidden(true)
+    onClose()
+  }
 
   useEffect(() => {
     if (!autoDismiss) {
@@ -39,19 +52,19 @@ export function Snackbar({
     }
 
     const timeout = globalThis.setTimeout(() => {
-      onClose()
+      handleClose()
     }, dismissAfterMs)
 
     return () => {
       globalThis.clearTimeout(timeout)
     }
-  }, [autoDismiss, dismissAfterMs, onClose])
+  }, [autoDismiss, dismissAfterMs, handleClose])
 
   return (
     <div className='seam-snackbar-wrap'>
       <div
         className={classNames('seam-snackbar', {
-          'seam-snackbar-visible': visible,
+          'seam-snackbar-visible': automaticVisibility ? !hidden : visible,
         })}
       >
         <SnackbarIcon variant={variant} />
@@ -71,7 +84,7 @@ export function Snackbar({
             <button
               className='seam-snackbar-close-button'
               onClick={() => {
-                onClose()
+                handleClose()
               }}
             >
               <CloseWhiteIcon />

--- a/src/lib/ui/Snackbar/Snackbar.tsx
+++ b/src/lib/ui/Snackbar/Snackbar.tsx
@@ -37,14 +37,14 @@ export function Snackbar({
 
   useEffect(() => {
     setHidden(!visible)
-  }, [visible])
+  }, [visible, setHidden])
 
   const { label: actionLabel, onClick: handleActionClick } = action ?? {}
 
   const handleClose = useCallback(() => {
     setHidden(true)
     onClose()
-  }, [onClose])
+  }, [onClose, setHidden])
 
   useEffect(() => {
     if (!autoDismiss) {

--- a/src/lib/ui/Snackbar/Snackbar.tsx
+++ b/src/lib/ui/Snackbar/Snackbar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { CheckGreenIcon } from 'lib/icons/CheckGreen.js'
 import { CloseWhiteIcon } from 'lib/icons/CloseWhite.js'
@@ -41,10 +41,10 @@ export function Snackbar({
 
   const { label: actionLabel, onClick: handleActionClick } = action ?? {}
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setHidden(true)
     onClose()
-  }
+  }, [onClose])
 
   useEffect(() => {
     if (!autoDismiss) {


### PR DESCRIPTION
The `automaticVisibility` prop lets the `Snackbar` component manage its own visibility, without changing existing functionality. This is useful for scenarios where visibility is determined by query results like `isError` or `isSuccess`. This feature solves the problem of needing extra logic to hide the `Snackbar`. Existing implementations are unaffected; this is an opt-in feature.