### PR TITLE
fix: SupportedDeviceTable SeeAll button position

### DIFF
--- a/src/styles/_supported-device-table.scss
+++ b/src/styles/_supported-device-table.scss
@@ -173,6 +173,7 @@ $row-padding: 8px;
         0 1px 1px 0 rgb(16 27 37 / 10%),
         0 1px 8px 0 rgb(46 69 82 / 12%);
       position: absolute;
+      bottom: -13px; //  (64px row - 30px button - 8px padding) / 2
       left: 50%;
       transform: translate(-50%, -47px);
       z-index: 3;

--- a/src/styles/_supported-device-table.scss
+++ b/src/styles/_supported-device-table.scss
@@ -1,6 +1,8 @@
 @use './colors';
 
+$row-height: 64px;
 $row-padding: 8px;
+$see-all-button-height: 30px;
 
 @mixin all {
   .seam-supported-device-table-content-wrap {
@@ -160,7 +162,7 @@ $row-padding: 8px;
       cursor: pointer;
       background: colors.$white;
       display: flex;
-      height: 30px;
+      height: $see-all-button-height;
       padding: 5px 24px 4px 16px;
       align-items: center;
       gap: 2px;
@@ -173,7 +175,7 @@ $row-padding: 8px;
         0 1px 1px 0 rgb(16 27 37 / 10%),
         0 1px 8px 0 rgb(46 69 82 / 12%);
       position: absolute;
-      bottom: -13px; //  (64px row - 30px button - 8px padding) / 2
+      bottom: -($row-height - $see-all-button-height - $row-padding) / 2;
       left: 50%;
       transform: translate(-50%, -47px);
       z-index: 3;
@@ -190,7 +192,7 @@ $row-padding: 8px;
         #fff 86.98%
       );
       position: absolute;
-      height: 64px;
+      height: $row-height;
       width: 100%;
       bottom: 0;
       z-index: 2;
@@ -268,7 +270,7 @@ $row-padding: 8px;
     border-collapse: collapse;
 
     .seam-row {
-      height: 64px;
+      height: $row-height;
       border-bottom: 1px solid colors.$bg-b;
       display: flex;
 


### PR DESCRIPTION
closes #580  

Should now be centered on the final row.

### Before

![image](https://github.com/seamapi/react/assets/11449462/4d0aed5f-5ac3-4fc3-9e7d-ad0f5e7bf29d)

### After

![CleanShot 2024-01-08 at 22 14 49](https://github.com/seamapi/react/assets/11449462/6f530ff0-334b-4108-bc4c-430fc977c225)
