### PR TITLE
Revert "Add `hideAccessCodes` flag to device table (#583)"

### DIFF
--- a/src/lib/seam/components/DeviceDetails/DeviceDetails.element.ts
+++ b/src/lib/seam/components/DeviceDetails/DeviceDetails.element.ts
@@ -6,7 +6,6 @@ export const name = 'seam-device-details'
 
 export const props: ElementProps<DeviceDetailsProps> = {
   deviceId: 'string',
-  hideAccessCodes: 'boolean',
 }
 
 export { DeviceDetails as Component } from './DeviceDetails.js'

--- a/src/lib/seam/components/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/DeviceDetails.tsx
@@ -12,7 +12,6 @@ import { useDevice } from 'lib/seam/devices/use-device.js'
 
 export interface DeviceDetailsProps extends CommonProps {
   deviceId: string
-  hideAccessCodes?: boolean
 }
 
 export const NestedDeviceDetails = withRequiredCommonProps(DeviceDetails)
@@ -22,7 +21,6 @@ export function DeviceDetails({
   disableLockUnlock = false,
   disableDeleteAccessCode = false,
   disableResourceIds = false,
-  hideAccessCodes = false,
   onBack,
   className,
 }: DeviceDetailsProps): JSX.Element | null {
@@ -40,7 +38,6 @@ export function DeviceDetails({
     disableLockUnlock,
     disableDeleteAccessCode,
     disableResourceIds,
-    hideAccessCodes,
     onBack,
     className,
   }

--- a/src/lib/seam/components/DeviceDetails/LockDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/LockDeviceDetails.tsx
@@ -18,7 +18,6 @@ import { useToggle } from 'lib/ui/use-toggle.js'
 
 interface LockDeviceDetailsProps extends CommonProps {
   device: LockDevice
-  hideAccessCodes?: boolean
 }
 
 export function LockDeviceDetails(
@@ -33,7 +32,6 @@ export function LockDeviceDetails(
     disableEditAccessCode,
     disableDeleteAccessCode,
     disableResourceIds,
-    hideAccessCodes,
     onBack,
     className,
   } = props
@@ -110,19 +108,17 @@ export function LockDeviceDetails(
           </div>
           <Alerts alerts={alerts} className='seam-alerts-space-top' />
         </div>
-        {hideAccessCodes !== true && (
-          <div className='seam-box'>
-            <div
-              className='seam-content seam-access-codes'
-              onClick={toggleAccessCodesOpen}
-            >
-              <span className='seam-value'>
-                {accessCodeCount} {t.accessCodes}
-              </span>
-              <ChevronRightIcon />
-            </div>
+        <div className='seam-box'>
+          <div
+            className='seam-content seam-access-codes'
+            onClick={toggleAccessCodesOpen}
+          >
+            <span className='seam-value'>
+              {accessCodeCount} {t.accessCodes}
+            </span>
+            <ChevronRightIcon />
           </div>
-        )}
+        </div>
 
         <div className='seam-box'>
           <div className='seam-content seam-lock-status'>

--- a/src/lib/seam/components/DeviceTable/DeviceTable.element.ts
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.element.ts
@@ -13,7 +13,6 @@ export const props: ElementProps<Omit<DeviceTableProps, 'title'>> = {
   onDeviceClick: 'object',
   preventDefaultOnDeviceClick: 'boolean',
   heading: 'string',
-  hideAccessCodes: 'boolean',
 }
 
 export { DeviceTable as Component } from './DeviceTable.js'

--- a/src/lib/seam/components/DeviceTable/DeviceTable.tsx
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.tsx
@@ -40,7 +40,6 @@ export interface DeviceTableProps extends CommonProps {
   deviceComparator?: (deviceA: Device, deviceB: Device) => number
   onDeviceClick?: (deviceId: string) => void
   preventDefaultOnDeviceClick?: boolean
-  hideAccessCodes?: boolean
   heading?: string | null
 }
 
@@ -71,7 +70,6 @@ export function DeviceTable({
   disableEditAccessCode = false,
   disableDeleteAccessCode = false,
   disableResourceIds = false,
-  hideAccessCodes = false,
   onBack,
   className,
 }: DeviceTableProps = {}): JSX.Element {
@@ -114,7 +112,6 @@ export function DeviceTable({
         disableEditAccessCode={disableEditAccessCode}
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
-        hideAccessCodes={hideAccessCodes}
         onBack={() => {
           setSelectedDeviceId(null)
         }}


### PR DESCRIPTION
This reverts commit fde0c1cfe1e6cb30668c336f28a39960753252a7.

This prop introduces granular customization that is currently out of scope of this project. The recommended work around to hide arbitrary element is to target the CSS classes.
