### PR TITLE
fix: Error in some contexts when using Error.captureStackTrace()

### DIFF
--- a/src/lib/seam/SeamProvider.tsx
+++ b/src/lib/seam/SeamProvider.tsx
@@ -273,6 +273,5 @@ class InvalidSeamProviderProps extends Error {
   constructor(message: string) {
     super(`SeamProvider received invalid props: ${message}`)
     this.name = this.constructor.name
-    Error.captureStackTrace(this, this.constructor)
   }
 }


### PR DESCRIPTION
This only exists in v8 contexts and was throwing in Firefox.

It's [not needed](https://stackoverflow.com/a/64063868) when extending the Error class.
