### PR TITLE
fix(DeviceDetails): Context menu does not respect `disableCreateAccessCode` and `disableEditAccessCode`

### DIFF
--- a/src/lib/seam/components/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/DeviceDetails.tsx
@@ -21,6 +21,8 @@ export function DeviceDetails({
   disableLockUnlock = false,
   disableDeleteAccessCode = false,
   disableResourceIds = false,
+  disableCreateAccessCode = false,
+  disableEditAccessCode = false,
   onBack,
   className,
 }: DeviceDetailsProps): JSX.Element | null {
@@ -38,6 +40,8 @@ export function DeviceDetails({
     disableLockUnlock,
     disableDeleteAccessCode,
     disableResourceIds,
+    disableCreateAccessCode,
+    disableEditAccessCode,
     onBack,
     className,
   }


### PR DESCRIPTION
The "disableCreateAccessCode" and "disableEditAccessCode" property flags are not properly passed through DeviceDetails, so there is no way to disable the edit and create buttons.

<img width="1694" alt="Screenshot 2024-02-27 at 1 12 49 PM" src="https://github.com/seamapi/react/assets/155990782/1f586838-9519-4d49-813b-cc2298ab66cb">
<img width="1694" alt="Screenshot 2024-02-27 at 1 13 23 PM" src="https://github.com/seamapi/react/assets/155990782/90e9c0fd-7531-4f69-a6b0-6f6c81ae9157">

