### PR TITLE
fix: Hide Lock/Unlock button on unsupported devices

### DIFF
--- a/src/lib/seam/components/DeviceDetails/LockDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/LockDeviceDetails.tsx
@@ -127,16 +127,17 @@ export function LockDeviceDetails(
               <span className='seam-value'>{lockStatus}</span>
             </div>
             <div className='seam-right'>
-              {disableLockUnlock !== true && (
-                <Button
-                  size='small'
-                  onClick={() => {
-                    toggleLock.mutate()
-                  }}
-                >
-                  {toggleLockLabel}
-                </Button>
-              )}
+              {disableLockUnlock !== true &&
+                device.capabilities_supported.includes('lock') && (
+                  <Button
+                    size='small'
+                    onClick={() => {
+                      toggleLock.mutate()
+                    }}
+                  >
+                    {toggleLockLabel}
+                  </Button>
+                )}
             </div>
           </div>
           <AccessCodeLength


### PR DESCRIPTION
Closes #592 • Only show Lock/Unlock button when `capabilities_supported` includes `"lock"`