### PR TITLE
fix: Hide border on `DetailRow:last-of-type`

### DIFF
--- a/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
@@ -166,22 +166,25 @@ function ManualOverrideRow({
 
   return (
     <>
-      <DetailRow label={t.allowManualOverride}>
-        <Switch
-          checked={
-            device.properties.default_climate_setting
-              ?.manual_override_allowed ?? true
-          }
-          onChange={(checked) => {
-            mutate({
-              device_id: device.device_id,
-              default_climate_setting: {
-                manual_override_allowed: checked,
-              },
-            })
-          }}
-        />
-      </DetailRow>
+      <div className='seam-detail-row-wrap'>
+        <DetailRow label={t.allowManualOverride}>
+          <Switch
+            checked={
+              device.properties.default_climate_setting
+                ?.manual_override_allowed ?? true
+            }
+            onChange={(checked) => {
+              mutate({
+                device_id: device.device_id,
+                default_climate_setting: {
+                  manual_override_allowed: checked,
+                },
+              })
+            }}
+          />
+        </DetailRow>
+      </div>
+
       <Snackbar
         message={t.manualOverrideSuccess}
         variant='success'
@@ -204,17 +207,19 @@ function FanModeRow({ device }: { device: ThermostatDevice }): JSX.Element {
 
   return (
     <>
-      <DetailRow label={t.fanMode}>
-        <FanModeMenu
-          mode={device.properties.fan_mode_setting}
-          onChange={(fanMode) => {
-            mutate({
-              device_id: device.device_id,
-              fan_mode_setting: fanMode,
-            })
-          }}
-        />
-      </DetailRow>
+      <div className='seam-detail-row-wrap'>
+        <DetailRow label={t.fanMode}>
+          <FanModeMenu
+            mode={device.properties.fan_mode_setting}
+            onChange={(fanMode) => {
+              mutate({
+                device_id: device.device_id,
+                fan_mode_setting: fanMode,
+              })
+            }}
+          />
+        </DetailRow>
+      </div>
 
       <Snackbar
         message={t.fanModeSuccess}

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -69,7 +69,6 @@
 }
 
 @mixin detail-row-common {
-
   .seam-detail-row,
   .seam-accordion-row {
     background-color: colors.$white;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -69,6 +69,7 @@
 }
 
 @mixin detail-row-common {
+
   .seam-detail-row,
   .seam-accordion-row {
     background-color: colors.$white;


### PR DESCRIPTION
Fixes an issue where the border of the last `DetailRow` would be visible. This is because the SCSS uses the `:not(:last-of-type)` selector, which operates on element type. To fix it, we needed to make sure that `DetailRow` was the last `div` in any given child `div`. This PR simply wraps those two exceptional elements in an intermediary `div`.

## Before

Under "Fan mode" and "Allow manual override"

<img width="732" alt="Screenshot 2024-02-29 at 3 30 26 PM" src="https://github.com/seamapi/react/assets/87919558/c9a1bae5-2d1b-47b7-b85e-1f0bc15894fa">

## After

<img width="732" alt="Screenshot 2024-02-29 at 3 29 41 PM" src="https://github.com/seamapi/react/assets/87919558/8fb7d25a-9814-4cb7-8505-3b2e03181f69">
