### PR TITLE
fix: Hide default climate settings with `disableClimateSettingSchedules`

### DIFF
--- a/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
@@ -123,23 +123,25 @@ export function ThermostatDeviceDetails({
               <FanModeRow device={device} />
             </DetailSection>
 
-            <DetailSection
-              label={t.defaultSettings}
-              tooltipContent={t.defaultSettingsTooltip}
-            >
-              <DetailRow label={t.defaultClimate}>
-                {device.properties.default_climate_setting != null ? (
-                  <ClimateSettingStatus
-                    climateSetting={device.properties.default_climate_setting}
-                    temperatureUnit='fahrenheit'
-                  />
-                ) : (
-                  <p>{t.none}</p>
-                )}
-              </DetailRow>
+            {!disableClimateSettingSchedules && (
+              <DetailSection
+                label={t.defaultSettings}
+                tooltipContent={t.defaultSettingsTooltip}
+              >
+                <DetailRow label={t.defaultClimate}>
+                  {device.properties.default_climate_setting != null ? (
+                    <ClimateSettingStatus
+                      climateSetting={device.properties.default_climate_setting}
+                      temperatureUnit='fahrenheit'
+                    />
+                  ) : (
+                    <p>{t.none}</p>
+                  )}
+                </DetailRow>
 
-              <ManualOverrideRow device={device} />
-            </DetailSection>
+                <ManualOverrideRow device={device} />
+              </DetailSection>
+            )}
 
             <DetailSection label={t.deviceDetails}>
               <DetailRow label={t.manufacturer}>


### PR DESCRIPTION
Fixes #601 

## Video

https://github.com/seamapi/react/assets/87919558/211d3686-9fb9-4ef5-a7aa-b4533ad1025a