### PR TITLE
feat(AccessCode): hide code inputs for offline codes

### DIFF
--- a/src/lib/ui/AccessCodeForm/AccessCodeForm.tsx
+++ b/src/lib/ui/AccessCodeForm/AccessCodeForm.tsx
@@ -176,6 +176,9 @@ function Content({
       ? t.codeLengthRequirement(codeLengthRequirement)
       : null
 
+  const hasCodeInputs =
+    accessCode?.type !== 'time_bound' || accessCode.is_offline_access_code
+
   return (
     <>
       <ContentHeader
@@ -207,77 +210,81 @@ function Content({
               }}
             />
           </FormField>
-          <FormField className='seam-code-field'>
-            <InputLabel>{t.codeInputLabel}</InputLabel>
-            <TextField
-              size='large'
-              clearable
-              hasError={hasCodeError}
-              helperText={responseErrors?.code ?? errors.code?.message}
-              inputProps={{
-                ...register('code', {
-                  required: t.codeRequiredError,
-                  validate: (value: string) =>
-                    validateCodeLength(device, value),
-                }),
-              }}
-            />
-            <div
-              className={classNames('seam-bottom', {
-                'has-hints': codeLengthRequirementMessage != null,
-              })}
-            >
-              {codeLengthRequirementMessage != null && (
-                <ul
-                  className={classNames('seam-requirements', {
-                    'seam-error': hasCodeError,
-                  })}
-                >
-                  <li>{codeLengthRequirementMessage}</li>
-                  <li>{t.codeNumbersOnlyRequirement}</li>
-                </ul>
-              )}
-              <Button
-                size='small'
-                onMouseDown={(e) => {
-                  e.preventDefault() // Disable stealing input focus
-                  handleGenerateCode()
-                }}
-                disabled={isGeneratingCode}
-              >
-                {t.codeGenerateButton}
-              </Button>
-            </div>
-          </FormField>
-          <FormField>
-            <InputLabel>{t.timingInputLabel}</InputLabel>
-            <RadioField
-              value={type}
-              onChange={setType}
-              name='type'
-              options={[
-                {
-                  label: t.typeOngoingLabel,
-                  value: 'ongoing',
-                },
-                {
-                  label: t.typeTimeBoundLabel,
-                  value: 'time_bound',
-                },
-              ]}
-            />
+          {hasCodeInputs && (
             <>
-              {type === 'time_bound' && (
-                <AccessCodeFormTimes
-                  startDate={startDate}
-                  endDate={endDate}
-                  onEdit={() => {
-                    setDatePickerVisible(true)
+              <FormField className='seam-code-field'>
+                <InputLabel>{t.codeInputLabel}</InputLabel>
+                <TextField
+                  size='large'
+                  clearable
+                  hasError={hasCodeError}
+                  helperText={responseErrors?.code ?? errors.code?.message}
+                  inputProps={{
+                    ...register('code', {
+                      required: t.codeRequiredError,
+                      validate: (value: string) =>
+                        validateCodeLength(device, value),
+                    }),
                   }}
                 />
-              )}
+                <div
+                  className={classNames('seam-bottom', {
+                    'has-hints': codeLengthRequirementMessage != null,
+                  })}
+                >
+                  {codeLengthRequirementMessage != null && (
+                    <ul
+                      className={classNames('seam-requirements', {
+                        'seam-error': hasCodeError,
+                      })}
+                    >
+                      <li>{codeLengthRequirementMessage}</li>
+                      <li>{t.codeNumbersOnlyRequirement}</li>
+                    </ul>
+                  )}
+                  <Button
+                    size='small'
+                    onMouseDown={(e) => {
+                      e.preventDefault() // Disable stealing input focus
+                      handleGenerateCode()
+                    }}
+                    disabled={isGeneratingCode}
+                  >
+                    {t.codeGenerateButton}
+                  </Button>
+                </div>
+              </FormField>
+              <FormField>
+                <InputLabel>{t.timingInputLabel}</InputLabel>
+                <RadioField
+                  value={type}
+                  onChange={setType}
+                  name='type'
+                  options={[
+                    {
+                      label: t.typeOngoingLabel,
+                      value: 'ongoing',
+                    },
+                    {
+                      label: t.typeTimeBoundLabel,
+                      value: 'time_bound',
+                    },
+                  ]}
+                />
+                <>
+                  {type === 'time_bound' && (
+                    <AccessCodeFormTimes
+                      startDate={startDate}
+                      endDate={endDate}
+                      onEdit={() => {
+                        setDatePickerVisible(true)
+                      }}
+                    />
+                  )}
+                </>
+              </FormField>
             </>
-          </FormField>
+          )}
           {responseErrors?.unknown != null && (
             <div className='seam-unknown-error'>{responseErrors?.unknown}</div>
           )}


### PR DESCRIPTION
closes #591

### Screenshots

#### Normal Access Code

![CleanShot 2024-03-15 at 16 37 55@2x](https://github.com/seamapi/react/assets/11449462/18637e95-25b8-48f3-ad0f-fb6e665c9dbe)

#### Hidden inputs (offline access code)

![CleanShot 2024-03-15 at 16 40 11@2x](https://github.com/seamapi/react/assets/11449462/54ab0e5c-b4cd-4483-b317-f13f7a8d6e2d)
