### PR TITLE
feat: Add `disableDeviceDetails`

### DIFF
--- a/src/lib/element.tsx
+++ b/src/lib/element.tsx
@@ -47,6 +47,7 @@ const commonProps: R2wcProps<CommonProps> = {
   disableDeleteAccessCode: 'boolean',
   disableResourceIds: 'boolean',
   disableClimateSettingSchedules: 'boolean',
+  disableDeviceDetails: 'boolean',
   onBack: 'object',
   className: 'string',
 }

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -43,6 +43,7 @@ export function AccessCodeDetails({
   disableDeleteAccessCode = false,
   disableResourceIds = false,
   disableClimateSettingSchedules,
+  disableDeviceDetails,
   onBack,
   className,
 }: AccessCodeDetailsProps): JSX.Element | null {
@@ -70,6 +71,7 @@ export function AccessCodeDetails({
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
         disableClimateSettingSchedules={disableClimateSettingSchedules}
+        disableDeviceDetails={disableDeviceDetails}
         onBack={() => {
           selectDevice(null)
         }}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -84,6 +84,7 @@ export function AccessCodeTable({
   disableDeleteAccessCode = false,
   disableResourceIds = false,
   disableClimateSettingSchedules,
+  disableDeviceDetails,
 }: AccessCodeTableProps): JSX.Element {
   useComponentTelemetry('AccessCodeTable')
 
@@ -148,6 +149,7 @@ export function AccessCodeTable({
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
         disableClimateSettingSchedules={disableClimateSettingSchedules}
+        disableDeviceDetails={disableDeviceDetails}
         onBack={() => {
           setSelectedEditAccessCodeId(null)
         }}
@@ -184,6 +186,7 @@ export function AccessCodeTable({
           disableDeleteAccessCode={disableDeleteAccessCode}
           disableResourceIds={disableResourceIds}
           disableClimateSettingSchedules={disableClimateSettingSchedules}
+          disableDeviceDetails={disableDeviceDetails}
           onBack={() => {
             setSelectedViewAccessCodeId(null)
           }}
@@ -205,6 +208,7 @@ export function AccessCodeTable({
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
         disableClimateSettingSchedules={disableClimateSettingSchedules}
+        disableDeviceDetails={disableDeviceDetails}
         onBack={toggleAddAccessCodeForm}
         className={className}
         onSuccess={() => {

--- a/src/lib/seam/components/ClimateSettingScheduleDetails/ClimateSettingScheduleDetails.tsx
+++ b/src/lib/seam/components/ClimateSettingScheduleDetails/ClimateSettingScheduleDetails.tsx
@@ -38,6 +38,7 @@ export function ClimateSettingScheduleDetails({
   disableEditAccessCode,
   disableResourceIds = false,
   disableClimateSettingSchedules,
+  disableDeviceDetails,
 }: ClimateSettingScheduleDetailsProps): JSX.Element | null {
   useComponentTelemetry('ClimateSettingScheduleDetails')
 
@@ -66,6 +67,7 @@ export function ClimateSettingScheduleDetails({
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
         disableClimateSettingSchedules={disableClimateSettingSchedules}
+        disableDeviceDetails={disableDeviceDetails}
         onBack={() => {
           selectDevice(null)
         }}

--- a/src/lib/seam/components/ClimateSettingScheduleTable/ClimateSettingScheduleTable.tsx
+++ b/src/lib/seam/components/ClimateSettingScheduleTable/ClimateSettingScheduleTable.tsx
@@ -72,6 +72,7 @@ export function ClimateSettingScheduleTable({
   disableEditAccessCode,
   disableResourceIds = false,
   disableClimateSettingSchedules,
+  disableDeviceDetails,
 }: ClimateSettingScheduleTableProps): JSX.Element {
   useComponentTelemetry('ClimateSettingScheduleTable')
 
@@ -126,6 +127,7 @@ export function ClimateSettingScheduleTable({
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
         disableClimateSettingSchedules={disableClimateSettingSchedules}
+        disableDeviceDetails={disableDeviceDetails}
         onBack={() => {
           setSelectedViewClimateSettingScheduleId(null)
         }}

--- a/src/lib/seam/components/DeviceDetails/DeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/DeviceDetails.tsx
@@ -23,6 +23,7 @@ export function DeviceDetails({
   disableCreateAccessCode = false,
   disableEditAccessCode = false,
   disableClimateSettingSchedules = false,
+  disableDeviceDetails = false,
   onBack,
   className,
 }: DeviceDetailsProps): JSX.Element | null {
@@ -43,6 +44,7 @@ export function DeviceDetails({
     disableCreateAccessCode,
     disableEditAccessCode,
     disableClimateSettingSchedules,
+    disableDeviceDetails,
     onBack,
     className,
   }

--- a/src/lib/seam/components/DeviceDetails/LockDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/LockDeviceDetails.tsx
@@ -33,6 +33,7 @@ export function LockDeviceDetails(
     disableDeleteAccessCode,
     disableResourceIds,
     disableClimateSettingSchedules,
+    disableDeviceDetails,
     onBack,
     className,
   } = props
@@ -64,6 +65,7 @@ export function LockDeviceDetails(
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
         disableClimateSettingSchedules={disableClimateSettingSchedules}
+        disableDeviceDetails={disableDeviceDetails}
         onBack={toggleAccessCodesOpen}
         className={className}
       />

--- a/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
@@ -46,6 +46,7 @@ export function ThermostatDeviceDetails({
   disableDeleteAccessCode,
   disableResourceIds = false,
   disableClimateSettingSchedules = false,
+  disableDeviceDetails = false,
 }: ThermostatDeviceDetailsProps): JSX.Element | null {
   const [climateSettingsOpen, setClimateSettingsOpen] = useState(false)
 
@@ -67,6 +68,7 @@ export function ThermostatDeviceDetails({
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
         disableClimateSettingSchedules={disableClimateSettingSchedules}
+        disableDeviceDetails={disableDeviceDetails}
         onBack={() => {
           setClimateSettingsOpen(false)
         }}
@@ -143,24 +145,26 @@ export function ThermostatDeviceDetails({
               </DetailSection>
             )}
 
-            <DetailSection label={t.deviceDetails}>
-              <DetailRow label={t.manufacturer}>
-                <div className='seam-detail-row-hstack'>
-                  {device.properties.model.manufacturer_display_name}
-                  {device.properties.manufacturer === 'ecobee' && <BeeIcon />}
-                </div>
-              </DetailRow>
-              <DetailRow
-                label={t.linkedAccount}
-                sublabel={
-                  connectedAccount?.user_identifier?.email ??
-                  device.connected_account_id
-                }
-              />
-              {!disableResourceIds && (
-                <DetailRow label={t.deviceId} sublabel={device.device_id} />
-              )}
-            </DetailSection>
+            {!disableDeviceDetails && (
+              <DetailSection label={t.deviceDetails}>
+                <DetailRow label={t.manufacturer}>
+                  <div className='seam-detail-row-hstack'>
+                    {device.properties.model.manufacturer_display_name}
+                    {device.properties.manufacturer === 'ecobee' && <BeeIcon />}
+                  </div>
+                </DetailRow>
+                <DetailRow
+                  label={t.linkedAccount}
+                  sublabel={
+                    connectedAccount?.user_identifier?.email ??
+                    device.connected_account_id
+                  }
+                />
+                {!disableResourceIds && (
+                  <DetailRow label={t.deviceId} sublabel={device.device_id} />
+                )}
+              </DetailSection>
+            )}
           </DetailSectionGroup>
         </div>
       </div>

--- a/src/lib/seam/components/DeviceTable/DeviceTable.tsx
+++ b/src/lib/seam/components/DeviceTable/DeviceTable.tsx
@@ -70,6 +70,7 @@ export function DeviceTable({
   disableDeleteAccessCode = false,
   disableResourceIds = false,
   disableClimateSettingSchedules = false,
+  disableDeviceDetails = false,
   onBack,
   className,
 }: DeviceTableProps = {}): JSX.Element {
@@ -113,6 +114,7 @@ export function DeviceTable({
         disableDeleteAccessCode={disableDeleteAccessCode}
         disableResourceIds={disableResourceIds}
         disableClimateSettingSchedules={disableClimateSettingSchedules}
+        disableDeviceDetails={disableDeviceDetails}
         onBack={() => {
           setSelectedDeviceId(null)
         }}

--- a/src/lib/seam/components/common-props.tsx
+++ b/src/lib/seam/components/common-props.tsx
@@ -19,6 +19,7 @@ export interface RequiredCommonProps {
   disableLockUnlock: boolean | undefined
   disableResourceIds: boolean | undefined
   disableClimateSettingSchedules: boolean | undefined
+  disableDeviceDetails: boolean | undefined
 }
 
 export type CommonProps = Partial<RequiredCommonProps>


### PR DESCRIPTION
Adds `disableDeviceDetails` prop to hide details in `ThermostatDeviceDetails`.

Should this be renamed to be more specific? `disableThermostatDeviceDetails`?

https://github.com/seamapi/react/assets/87919558/22b130f5-5aa9-444c-94e8-8ee58dd84f9c