### PR TITLE
fix: Show temperature in climate setting rows

### DIFF
--- a/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/ThermostatDeviceDetails.tsx
@@ -133,6 +133,7 @@ export function ThermostatDeviceDetails({
                     <ClimateSettingStatus
                       climateSetting={device.properties.default_climate_setting}
                       temperatureUnit='fahrenheit'
+                      iconPlacement='right'
                     />
                   ) : (
                     <p>{t.none}</p>
@@ -397,6 +398,7 @@ function ClimateSettingRow({
           <ClimateSettingStatus
             climateSetting={device.properties.current_climate_setting}
             temperatureUnit='fahrenheit'
+            iconPlacement='right'
           />
         }
       >

--- a/src/lib/ui/thermostat/ClimateSettingStatus.tsx
+++ b/src/lib/ui/thermostat/ClimateSettingStatus.tsx
@@ -69,16 +69,16 @@ function Content(props: {
 }): JSX.Element | null {
   const { mode, coolingSetPoint, heatingSetPoint, temperatureUnit } = props
 
-  if (mode === 'cool' && isSetPoint(coolingSetPoint))
+  if (mode === 'cool' && isSetPoint(coolingSetPoint, temperatureUnit))
     return <Temperature {...coolingSetPoint} unit={temperatureUnit} />
 
-  if (mode === 'heat' && isSetPoint(heatingSetPoint))
+  if (mode === 'heat' && isSetPoint(heatingSetPoint, temperatureUnit))
     return <Temperature {...heatingSetPoint} unit={temperatureUnit} />
 
   if (
     mode === 'heat_cool' &&
-    isSetPoint(heatingSetPoint) &&
-    isSetPoint(coolingSetPoint)
+    isSetPoint(heatingSetPoint, temperatureUnit) &&
+    isSetPoint(coolingSetPoint, temperatureUnit)
   )
     return (
       <span>
@@ -93,7 +93,12 @@ function Content(props: {
   return null
 }
 
-function isSetPoint(setPoint: Partial<SetPoint>): setPoint is SetPoint {
+function isSetPoint(
+  setPoint: Partial<SetPoint>,
+  temperatureUnit: 'fahrenheit' | 'celsius'
+): setPoint is SetPoint {
+  if (temperatureUnit === 'fahrenheit') return setPoint.fahrenheit != null
+  if (temperatureUnit === 'celsius') return setPoint.celsius != null
   return setPoint.fahrenheit != null && setPoint.celsius != null
 }
 


### PR DESCRIPTION
Fixes part of #605 • Shows the temperature in the climate setting status by fixing the dual condition in the `isSetPoint` function.

## Before

<img width="756" alt="Screenshot 2024-03-15 at 2 50 23 PM" src="https://github.com/seamapi/react/assets/87919558/aec64853-a6c3-4eca-9235-763a84fd2693">

## After

<img width="756" alt="Screenshot 2024-03-15 at 2 50 03 PM" src="https://github.com/seamapi/react/assets/87919558/b4554674-6164-488a-96d2-7456fcd2b405">