### PR TITLE
fix: use dynamic images as image size too large

### DIFF
--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceRow.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceRow.tsx
@@ -22,7 +22,7 @@ export function SupportedDeviceRow({
 export function ImageColumn({
   deviceModel,
 }: SupportedDeviceRowProps): JSX.Element {
-  const optimizedSrc = `https://console.seam.co/_next/image?url=${encodeURIComponent(deviceModel.aesthetic_variants[0]?.images[0]?.url ?? '')}&q=75&w=128`
+  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encodeURIComponent(deviceModel.aesthetic_variants[0]?.images[0]?.url ?? '')}&q=75&w=128`
 
   return (
     <div className='seam-col seam-device-image-col'>

--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceRow.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceRow.tsx
@@ -22,7 +22,7 @@ export function SupportedDeviceRow({
 export function ImageColumn({
   deviceModel,
 }: SupportedDeviceRowProps): JSX.Element {
-  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encodeURIComponent(deviceModel.aesthetic_variants[0]?.images[0]?.url ?? '')}&q=75&w=128`
+  const optimizedSrc = `https://console.seam.co/_next/image?url=${encodeURIComponent(deviceModel.aesthetic_variants[0]?.images[0]?.url ?? '')}&q=75&w=128`
 
   return (
     <div className='seam-col seam-device-image-col'>

--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceRow.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceRow.tsx
@@ -22,7 +22,7 @@ export function SupportedDeviceRow({
 export function ImageColumn({
   deviceModel,
 }: SupportedDeviceRowProps): JSX.Element {
-  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encodeURIComponent(deviceModel.aesthetic_variants[0]?.images[0]?.url)}&q=75&w=128`
+  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encodeURIComponent(deviceModel.aesthetic_variants[0]?.images[0]?.url ?? '')}&q=75&w=128`
 
   return (
     <div className='seam-col seam-device-image-col'>

--- a/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceRow.tsx
+++ b/src/lib/seam/components/SupportedDeviceTable/SupportedDeviceRow.tsx
@@ -22,13 +22,12 @@ export function SupportedDeviceRow({
 export function ImageColumn({
   deviceModel,
 }: SupportedDeviceRowProps): JSX.Element {
+  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encodeURIComponent(deviceModel.aesthetic_variants[0]?.images[0]?.url)}&q=75&w=128`
+
   return (
     <div className='seam-col seam-device-image-col'>
       <div className='seam-image-box'>
-        <img
-          width={40}
-          src={deviceModel.aesthetic_variants[0]?.images[0]?.url}
-        />
+        <img width={40} src={optimizedSrc} />
       </div>
     </div>
   )

--- a/src/lib/ui/device/DeviceImage.tsx
+++ b/src/lib/ui/device/DeviceImage.tsx
@@ -10,7 +10,7 @@ export function DeviceImage(
 
   const url = device.properties.image_url ?? fallbackImageUrl
 
-  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encodeURIComponent(url)}&q=75&w=128`
+  const optimizedSrc = `https://console.seam.co/_next/image?url=${encodeURIComponent(url)}&q=75&w=128`
 
   return <img src={optimizedSrc} alt={device.properties.name} {...imageProps} />
 }

--- a/src/lib/ui/device/DeviceImage.tsx
+++ b/src/lib/ui/device/DeviceImage.tsx
@@ -10,7 +10,7 @@ export function DeviceImage(
 
   const url = device.properties.image_url ?? fallbackImageUrl
 
-  const optimizedSrc = `https://console.seam.co/_next/image?url=${encodeURIComponent(url)}&q=75&w=128`
+  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encodeURIComponent(url)}&q=75&w=128`
 
   return <img src={optimizedSrc} alt={device.properties.name} {...imageProps} />
 }

--- a/src/lib/ui/device/DeviceImage.tsx
+++ b/src/lib/ui/device/DeviceImage.tsx
@@ -10,7 +10,14 @@ export function DeviceImage(
 
   const url = device.properties.image_url ?? fallbackImageUrl
 
-  return <img src={url} alt={device.properties.name} {...imageProps} />
+  const relativePath = url.match(/assets\/(.*)$/)[1]
+  const encoded = window.encodeURIComponent(relativePath)
+
+  const w = 256
+
+  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encoded}&w=${w}&q=75`
+
+  return <img src={optimizedSrc} alt={device.properties.name} {...imageProps} />
 }
 
 const fallbackImageUrl =

--- a/src/lib/ui/device/DeviceImage.tsx
+++ b/src/lib/ui/device/DeviceImage.tsx
@@ -8,20 +8,7 @@ export function DeviceImage(
 ): JSX.Element {
   const { device, ...imageProps } = props
 
-  const url = device.properties.image_url ?? fallbackImageUrl
-
-  const dbUrl =
-    'https://connect.getseam.com/internal/devicedb_image_proxy?image_id=92907fd0-a3d9-4cc8-9076-b743696d9259'
-
-  const relativePath = url.match(/assets\/(.*)$/)[1]
-  const encoded = window.encodeURIComponent(dbUrl)
-
-  const w = 128
-
-  const optimizedSrc = `http://localhost:3020/_next/image?url=${encoded}&w=${w}&q=75`
+  const optimizedSrc = `https://connect.getseam.com/_next/image?url=http%3A%2F%2Flocalhost%3A3020%2Finternal%2Fdevicedb_image_proxy%3Fimage_id%3D00e70527-3f8a-4631-ac11-c24e541e0fa5&q=75&w=128`
 
   return <img src={optimizedSrc} alt={device.properties.name} {...imageProps} />
 }
-
-const fallbackImageUrl =
-  'https://connect.getseam.com/assets/images/devices/unknown-lock.png'

--- a/src/lib/ui/device/DeviceImage.tsx
+++ b/src/lib/ui/device/DeviceImage.tsx
@@ -8,7 +8,12 @@ export function DeviceImage(
 ): JSX.Element {
   const { device, ...imageProps } = props
 
-  const optimizedSrc = `https://connect.getseam.com/_next/image?url=http%3A%2F%2Flocalhost%3A3020%2Finternal%2Fdevicedb_image_proxy%3Fimage_id%3D00e70527-3f8a-4631-ac11-c24e541e0fa5&q=75&w=128`
+  const url = device.properties.image_url ?? fallbackImageUrl
+
+  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encodeURIComponent(url)}&q=75&w=128`
 
   return <img src={optimizedSrc} alt={device.properties.name} {...imageProps} />
 }
+
+const fallbackImageUrl =
+  'https://connect.getseam.com/assets/images/devices/unknown-lock.png'

--- a/src/lib/ui/device/DeviceImage.tsx
+++ b/src/lib/ui/device/DeviceImage.tsx
@@ -10,12 +10,15 @@ export function DeviceImage(
 
   const url = device.properties.image_url ?? fallbackImageUrl
 
+  const dbUrl =
+    'https://connect.getseam.com/internal/devicedb_image_proxy?image_id=92907fd0-a3d9-4cc8-9076-b743696d9259'
+
   const relativePath = url.match(/assets\/(.*)$/)[1]
-  const encoded = window.encodeURIComponent(relativePath)
+  const encoded = window.encodeURIComponent(dbUrl)
 
-  const w = 256
+  const w = 128
 
-  const optimizedSrc = `https://connect.getseam.com/_next/image?url=${encoded}&w=${w}&q=75`
+  const optimizedSrc = `http://localhost:3020/_next/image?url=${encoded}&w=${w}&q=75`
 
   return <img src={optimizedSrc} alt={device.properties.name} {...imageProps} />
 }

--- a/vercel.json
+++ b/vercel.json
@@ -84,7 +84,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; connect-src 'self' https://connect.getseam.com; img-src 'self' https://connect.getseam.com https://console.seam.co; font-src 'self' https://fonts.gstatic.com; style-src 'self' https://fonts.googleapis.com"
+          "value": "default-src 'self'; connect-src 'self' https://connect.getseam.com; img-src 'self' https://connect.getseam.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' https://fonts.googleapis.com"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -93,7 +93,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'nonce-storybook'; connect-src 'self' https://connect.getseam.com; img-src 'self' https://connect.getseam.com https://img.shields.io https://github.com https://console.seam.co; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' http://fonts.googleapis.com"
+          "value": "default-src 'self'; script-src 'self' 'nonce-storybook'; connect-src 'self' https://connect.getseam.com; img-src 'self' https://connect.getseam.com https://img.shields.io https://github.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' http://fonts.googleapis.com"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -102,7 +102,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' data:; img-src 'self' https://img.shields.io https://github.com; style-src 'self' 'unsafe-inline'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' data:; img-src 'self' https://img.shields.io https://github.com https://console.seam.co; style-src 'self' 'unsafe-inline'"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -102,7 +102,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' data:; img-src 'self' https://img.shields.io https://github.com https://console.seam.co; style-src 'self' 'unsafe-inline'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' data:; img-src 'self' https://img.shields.io https://github.com; style-src 'self' 'unsafe-inline'"
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -84,7 +84,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; connect-src 'self' https://connect.getseam.com; img-src 'self' https://connect.getseam.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' https://fonts.googleapis.com"
+          "value": "default-src 'self'; connect-src 'self' https://connect.getseam.com; img-src 'self' https://connect.getseam.com https://console.seam.co; font-src 'self' https://fonts.gstatic.com; style-src 'self' https://fonts.googleapis.com"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -93,7 +93,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'nonce-storybook'; connect-src 'self' https://connect.getseam.com; img-src 'self' https://connect.getseam.com https://img.shields.io https://github.com; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' http://fonts.googleapis.com"
+          "value": "default-src 'self'; script-src 'self' 'nonce-storybook'; connect-src 'self' https://connect.getseam.com; img-src 'self' https://connect.getseam.com https://img.shields.io https://github.com https://console.seam.co; font-src 'self' https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' http://fonts.googleapis.com"
         }
       ]
     },


### PR DESCRIPTION
closes #616 

This is a POC. We'll use Next.js' `_next/image` directly to get a dynamic image size.

### Before

![CleanShot 2024-04-08 at 14 37 47@2x](https://github.com/seamapi/react/assets/11449462/8f4f4b5f-2223-4d45-b0fe-e48eb15c2bb4)

- not sure why in dev the image sizes are pretty small

### After

![CleanShot 2024-04-08 at 14 38 04@2x](https://github.com/seamapi/react/assets/11449462/ce52766a-2a41-450e-ba4f-002bd5a98d1b)

- images replaced by `webp` as expected

### Live storybook

https://react.seam.co/?path=/docs/components-devicetable--docs

I replaced the `src` attribute, and it's quite a big difference.

![CleanShot 2024-04-08 at 14 41 33@2x](https://github.com/seamapi/react/assets/11449462/cb061d28-19af-4664-9b3f-24d0deeb19e3)
