### PR TITLE
test: Use version of fake-devicedb that supports proxied image urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@mui/material": "^5.12.2",
         "@rollup/plugin-replace": "^5.0.5",
         "@rxfork/r2wc-react-to-web-component": "^2.4.0",
-        "@seamapi/fake-devicedb": "^1.6.0",
+        "@seamapi/fake-devicedb": "^1.6.1",
         "@seamapi/fake-seam-connect": "^1.69.1",
         "@seamapi/types": "^1.199.0",
         "@storybook/addon-designs": "^7.0.1",
@@ -5463,9 +5463,9 @@
       }
     },
     "node_modules/@seamapi/fake-devicedb": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@seamapi/fake-devicedb/-/fake-devicedb-1.6.0.tgz",
-      "integrity": "sha512-CuZ2caQf7CepZtBOnDe2VJj48X1tYGCa77kK636L281N/kNeJD897s9CysdUZ7O/b6p5fkXDY2IK0GnBEOnkEQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@seamapi/fake-devicedb/-/fake-devicedb-1.6.1.tgz",
+      "integrity": "sha512-w4Ar/s2kPnE5ExJSlpD3sKL8lkF+rLHRROArIRxtR2reHfnDSVwnDt9TzBYkHqgMP/x4o7LUzlRRpobn2xn24A==",
       "dev": true,
       "engines": {
         "node": ">=18.12.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@mui/material": "^5.12.2",
     "@rollup/plugin-replace": "^5.0.5",
     "@rxfork/r2wc-react-to-web-component": "^2.4.0",
-    "@seamapi/fake-devicedb": "^1.6.0",
+    "@seamapi/fake-devicedb": "^1.6.1",
     "@seamapi/fake-seam-connect": "^1.69.1",
     "@seamapi/types": "^1.199.0",
     "@storybook/addon-designs": "^7.0.1",


### PR DESCRIPTION
https://github.com/seamapi/react/issues/646 was fixed upstream, we want to use the new version that contains the fix