### PR TITLE
fix: Only support React 18 in version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,10 +84,10 @@
       },
       "peerDependencies": {
         "@seamapi/types": "^1.26.2",
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "^18.0.0",
+        "@types/react-dom": "^18.0.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       },
       "peerDependenciesMeta": {
         "@seamapi/types": {

--- a/package.json
+++ b/package.json
@@ -110,10 +110,10 @@
   },
   "peerDependencies": {
     "@seamapi/types": "^1.26.2",
-    "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "peerDependenciesMeta": {
     "@seamapi/types": {


### PR DESCRIPTION
react-query v5 requires React 18+: https://tanstack.com/query/latest/docs/framework/react/installation

So this is an additional breaking change for Version 3.