### PR TITLE
Display warning when access-code is being removed

### DIFF
--- a/.storybook/seed-fake.js
+++ b/.storybook/seed-fake.js
@@ -205,6 +205,20 @@ export const seedFake = (db) => {
     is_managed: true,
   })
 
+  db.addAccessCode({
+    device_id: device1.device_id,
+    workspace_id: ws2.workspace_id,
+    created_at: '2023-05-19T03:11:10.000',
+    name: "Luc's Front Door Code",
+    code: '4444',
+    common_code_key: null,
+    type: 'ongoing',
+    status: 'removing',
+    errors: [],
+    warnings: [],
+    is_managed: true,
+  })
+
   const device2 = db.addDevice({
     connected_account_id: ca.connected_account_id,
     device_type: 'august_lock',

--- a/src/lib/seam/access-codes/use-access-code.ts
+++ b/src/lib/seam/access-codes/use-access-code.ts
@@ -13,11 +13,12 @@ export type UseAccessCodeParams = AccessCodesGetParams
 export type UseAccessCodeData = AccessCode | null
 
 export function useAccessCode(
-  params: UseAccessCodeParams
+  params: UseAccessCodeParams,
+  isEnabled: boolean = true
 ): UseSeamQueryResult<'accessCode', UseAccessCodeData> {
   const { client } = useSeamClient()
   const { data, ...rest } = useQuery<UseAccessCodeData, SeamHttpApiError>({
-    enabled: client != null,
+    enabled: client != null && isEnabled,
     queryKey: ['access_codes', 'get', params],
     queryFn: async () => {
       if (client == null) return null

--- a/src/lib/seam/access-codes/use-access-code.ts
+++ b/src/lib/seam/access-codes/use-access-code.ts
@@ -13,12 +13,11 @@ export type UseAccessCodeParams = AccessCodesGetParams
 export type UseAccessCodeData = AccessCode | null
 
 export function useAccessCode(
-  params: UseAccessCodeParams,
-  isEnabled: boolean = true
+  params: UseAccessCodeParams
 ): UseSeamQueryResult<'accessCode', UseAccessCodeData> {
   const { client } = useSeamClient()
   const { data, ...rest } = useQuery<UseAccessCodeData, SeamHttpApiError>({
-    enabled: client != null && isEnabled,
+    enabled: client != null,
     queryKey: ['access_codes', 'get', params],
     queryFn: async () => {
       if (client == null) return null

--- a/src/lib/seam/access-codes/use-delete-access-code.ts
+++ b/src/lib/seam/access-codes/use-delete-access-code.ts
@@ -2,6 +2,7 @@ import type {
   AccessCodesDeleteParams,
   SeamHttpApiError,
 } from '@seamapi/http/connect'
+import type { AccessCode } from '@seamapi/types/connect'
 import {
   useMutation,
   type UseMutationResult,
@@ -42,6 +43,20 @@ export function useDeleteAccessCode(): UseMutationResult<
         ],
       })
       void queryClient.invalidateQueries({ queryKey: ['access_codes', 'list'] })
+
+      queryClient.setQueryData<AccessCode | null>(
+        ['access_codes', 'get', { access_code_id: variables.access_code_id }],
+        (accessCode) => {
+          if (accessCode == null) {
+            return
+          }
+
+          return {
+            ...accessCode,
+            status: 'removing',
+          }
+        }
+      )
     },
   })
 }

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
@@ -8,6 +8,7 @@ export const props: ElementProps<AccessCodeDetailsProps> = {
   accessCodeId: 'string',
   onEdit: 'object',
   onDeleteSuccess: 'object',
+  preventDefaultOnEdit: 'boolean',
 }
 
 export { AccessCodeDetails as Component } from './AccessCodeDetails.js'

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
@@ -7,7 +7,7 @@ export const name = 'seam-access-code-details'
 export const props: ElementProps<AccessCodeDetailsProps> = {
   accessCodeId: 'string',
   onEdit: 'object',
-  onDelete: 'object',
+  onDeleteSuccess: 'object',
 }
 
 export { AccessCodeDetails as Component } from './AccessCodeDetails.js'

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
@@ -7,6 +7,8 @@ export const name = 'seam-access-code-details'
 export const props: ElementProps<AccessCodeDetailsProps> = {
   accessCodeId: 'string',
   onEdit: 'object',
+  onDelete: 'object',
+  isBeingRemoved: 'boolean',
 }
 
 export { AccessCodeDetails as Component } from './AccessCodeDetails.js'

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
@@ -7,7 +7,6 @@ export const name = 'seam-access-code-details'
 export const props: ElementProps<AccessCodeDetailsProps> = {
   accessCodeId: 'string',
   onEdit: 'object',
-  onDeleteSuccess: 'object',
   preventDefaultOnEdit: 'boolean',
 }
 

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
@@ -8,7 +8,7 @@ export const props: ElementProps<AccessCodeDetailsProps> = {
   accessCodeId: 'string',
   onEdit: 'object',
   onDelete: 'object',
-  isBeingRemoved: 'boolean',
+  isAccessCodeBeingRemoved: 'boolean',
 }
 
 export { AccessCodeDetails as Component } from './AccessCodeDetails.js'

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
@@ -8,7 +8,6 @@ export const props: ElementProps<AccessCodeDetailsProps> = {
   accessCodeId: 'string',
   onEdit: 'object',
   onDelete: 'object',
-  isAccessCodeBeingRemoved: 'boolean',
 }
 
 export { AccessCodeDetails as Component } from './AccessCodeDetails.js'

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.element.ts
@@ -8,6 +8,8 @@ export const props: ElementProps<AccessCodeDetailsProps> = {
   accessCodeId: 'string',
   onEdit: 'object',
   preventDefaultOnEdit: 'boolean',
+  onDelete: 'object',
+  preventDefaultOnDelete: 'boolean',
 }
 
 export { AccessCodeDetails as Component } from './AccessCodeDetails.js'

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.stories.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.stories.tsx
@@ -65,3 +65,12 @@ export const DisableLockUnlock: Story = {
     />
   ),
 }
+
+export const AccessCodeBeingRemoved: Story = {
+  render: (props) => (
+    <AccessCodeDetails
+      {...props}
+      accessCodeId={props.accessCodeId ?? 'access_code5'}
+    />
+  ),
+}

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -27,7 +27,7 @@ import { useIsDateInPast } from 'lib/ui/use-is-date-in-past.js'
 export interface AccessCodeDetailsProps extends CommonProps {
   accessCodeId: string
   onEdit: () => void
-  onDelete: () => void
+  onDelete?: () => void
   isBeingRemoved?: boolean
 }
 

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -27,7 +27,7 @@ import { useIsDateInPast } from 'lib/ui/use-is-date-in-past.js'
 export interface AccessCodeDetailsProps extends CommonProps {
   accessCodeId: string
   onEdit: () => void
-  onDelete?: () => void
+  onDeleteSuccess?: () => void
 }
 
 export const NestedAccessCodeDetails =
@@ -36,7 +36,7 @@ export const NestedAccessCodeDetails =
 export function AccessCodeDetails({
   accessCodeId,
   onEdit,
-  onDelete,
+  onDeleteSuccess,
   errorFilter = () => true,
   warningFilter = () => true,
   disableCreateAccessCode = false,
@@ -160,7 +160,7 @@ export function AccessCodeDetails({
               onClick={() => {
                 deleteCode(
                   { access_code_id: accessCode.access_code_id },
-                  { onSuccess: onDelete }
+                  { onSuccess: onDeleteSuccess }
                 )
               }}
               disabled={isAccessCodeBeingRemoved || isDeleting}

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -28,7 +28,6 @@ export interface AccessCodeDetailsProps extends CommonProps {
   accessCodeId: string
   onEdit: () => void
   onDelete?: () => void
-  isAccessCodeBeingRemoved?: boolean
 }
 
 export const NestedAccessCodeDetails =
@@ -47,16 +46,12 @@ export function AccessCodeDetails({
   disableResourceIds = false,
   disableConnectedAccountInformation = false,
   disableClimateSettingSchedules,
-  isAccessCodeBeingRemoved,
   onBack,
   className,
 }: AccessCodeDetailsProps): JSX.Element | null {
   useComponentTelemetry('AccessCodeDetails')
 
-  const { accessCode } = useAccessCode(
-    { access_code_id: accessCodeId },
-    isAccessCodeBeingRemoved !== true
-  )
+  const { accessCode } = useAccessCode({ access_code_id: accessCodeId })
   const [selectedDeviceId, selectDevice] = useState<string | null>(null)
   const { mutate: deleteCode, isPending: isDeleting } = useDeleteAccessCode()
 
@@ -65,6 +60,7 @@ export function AccessCodeDetails({
   }
 
   const name = accessCode.name ?? t.fallbackName
+  const isAccessCodeBeingRemoved = accessCode.status === 'removing'
 
   if (selectedDeviceId != null) {
     return (
@@ -104,7 +100,7 @@ export function AccessCodeDetails({
         message: warning.message,
       })),
 
-    ...(isAccessCodeBeingRemoved === true
+    ...(isAccessCodeBeingRemoved
       ? [
           {
             variant: 'warning' as const,
@@ -153,7 +149,7 @@ export function AccessCodeDetails({
             <Button
               size='small'
               onClick={onEdit}
-              disabled={isAccessCodeBeingRemoved === true || isDeleting}
+              disabled={isAccessCodeBeingRemoved || isDeleting}
             >
               {t.editCode}
             </Button>
@@ -167,7 +163,7 @@ export function AccessCodeDetails({
                   { onSuccess: onDelete }
                 )
               }}
-              disabled={isAccessCodeBeingRemoved === true || isDeleting}
+              disabled={isAccessCodeBeingRemoved || isDeleting}
             >
               {t.deleteCode}
             </Button>

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -28,7 +28,7 @@ export interface AccessCodeDetailsProps extends CommonProps {
   accessCodeId: string
   onEdit: () => void
   onDelete?: () => void
-  isBeingRemoved?: boolean
+  isAccessCodeBeingRemoved?: boolean
 }
 
 export const NestedAccessCodeDetails =
@@ -47,7 +47,7 @@ export function AccessCodeDetails({
   disableResourceIds = false,
   disableConnectedAccountInformation = false,
   disableClimateSettingSchedules,
-  isBeingRemoved,
+  isAccessCodeBeingRemoved,
   onBack,
   className,
 }: AccessCodeDetailsProps): JSX.Element | null {
@@ -55,7 +55,7 @@ export function AccessCodeDetails({
 
   const { accessCode } = useAccessCode(
     { access_code_id: accessCodeId },
-    isBeingRemoved !== true
+    isAccessCodeBeingRemoved !== true
   )
   const [selectedDeviceId, selectDevice] = useState<string | null>(null)
   const { mutate: deleteCode, isPending: isDeleting } = useDeleteAccessCode()
@@ -104,7 +104,7 @@ export function AccessCodeDetails({
         message: warning.message,
       })),
 
-    ...(isBeingRemoved === true
+    ...(isAccessCodeBeingRemoved === true
       ? [
           {
             variant: 'warning' as const,
@@ -153,7 +153,7 @@ export function AccessCodeDetails({
             <Button
               size='small'
               onClick={onEdit}
-              disabled={isBeingRemoved === true || isDeleting}
+              disabled={isAccessCodeBeingRemoved === true || isDeleting}
             >
               {t.editCode}
             </Button>
@@ -167,7 +167,7 @@ export function AccessCodeDetails({
                   { onSuccess: onDelete }
                 )
               }}
-              disabled={isBeingRemoved === true || isDeleting}
+              disabled={isAccessCodeBeingRemoved === true || isDeleting}
             >
               {t.deleteCode}
             </Button>

--- a/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
+++ b/src/lib/seam/components/AccessCodeDetails/AccessCodeDetails.tsx
@@ -30,6 +30,8 @@ export interface AccessCodeDetailsProps extends CommonProps {
   accessCodeId: string
   onEdit?: () => void
   preventDefaultOnEdit?: boolean
+  onDelete?: () => void
+  preventDefaultOnDelete?: boolean
 }
 
 export const NestedAccessCodeDetails =
@@ -39,6 +41,8 @@ export function AccessCodeDetails({
   accessCodeId,
   onEdit,
   preventDefaultOnEdit = false,
+  onDelete,
+  preventDefaultOnDelete = false,
   errorFilter = () => true,
   warningFilter = () => true,
   disableCreateAccessCode = false,
@@ -76,6 +80,20 @@ export function AccessCodeDetails({
     if (preventDefaultOnEdit) return
     setEditFormOpen(true)
   }, [onEdit, preventDefaultOnEdit, setEditFormOpen])
+
+  const handleDelete = useCallback((): void => {
+    onDelete?.()
+    if (preventDefaultOnDelete) return
+    if (accessCode == null) return
+    deleteCode(
+      { access_code_id: accessCode.access_code_id },
+      {
+        onSuccess: () => {
+          setAccessCodeResult('deleted')
+        },
+      }
+    )
+  }, [accessCode, deleteCode, onDelete, preventDefaultOnDelete])
 
   if (accessCode == null) {
     return null
@@ -214,16 +232,7 @@ export function AccessCodeDetails({
             {!disableDeleteAccessCode && (
               <Button
                 size='small'
-                onClick={() => {
-                  deleteCode(
-                    { access_code_id: accessCode.access_code_id },
-                    {
-                      onSuccess: () => {
-                        setAccessCodeResult('deleted')
-                      },
-                    }
-                  )
-                }}
+                onClick={handleDelete}
                 disabled={isAccessCodeBeingRemoved || isDeleting}
               >
                 {t.deleteCode}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -15,8 +15,6 @@ export interface AccessCodeMenuProps {
   onViewDetails: () => void
   disableEditAccessCode: boolean
   disableDeleteAccessCode: boolean
-  deleteConfirmationVisible: boolean
-  toggleDeleteConfirmation: () => void
 }
 
 export function AccessCodeMenu(props: AccessCodeMenuProps): JSX.Element {
@@ -44,6 +42,11 @@ export function AccessCodeMenu(props: AccessCodeMenuProps): JSX.Element {
   )
 }
 
+interface ContentProps extends AccessCodeMenuProps {
+  deleteConfirmationVisible: boolean
+  toggleDeleteConfirmation: () => void
+}
+
 function Content({
   accessCode,
   onViewDetails,
@@ -53,7 +56,7 @@ function Content({
   onDelete,
   deleteConfirmationVisible,
   toggleDeleteConfirmation,
-}: AccessCodeMenuProps): JSX.Element {
+}: ContentProps): JSX.Element {
   const deleteAccessCode = useDeleteAccessCode()
 
   if (deleteConfirmationVisible) {

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -11,6 +11,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
 export interface AccessCodeMenuProps {
   accessCode: AccessCode
   onEdit: () => void
+  onDelete: () => void
   onViewDetails: () => void
   disableEditAccessCode: boolean
   disableDeleteAccessCode: boolean
@@ -49,6 +50,7 @@ function Content({
   disableEditAccessCode,
   disableDeleteAccessCode,
   onEdit,
+  onDelete,
   deleteConfirmationVisible,
   toggleDeleteConfirmation,
 }: AccessCodeMenuProps): JSX.Element {
@@ -66,9 +68,14 @@ function Content({
             variant='solid'
             disabled={deleteAccessCode.isPending}
             onClick={() => {
-              deleteAccessCode.mutate({
-                access_code_id: accessCode.access_code_id,
-              })
+              deleteAccessCode.mutate(
+                {
+                  access_code_id: accessCode.access_code_id,
+                },
+                {
+                  onSuccess: onDelete,
+                }
+              )
             }}
           >
             {t.confirmDelete}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -11,7 +11,7 @@ import { useToggle } from 'lib/ui/use-toggle.js'
 export interface AccessCodeMenuProps {
   accessCode: AccessCode
   onEdit: () => void
-  onDelete: () => void
+  onDeleteSuccess: () => void
   onViewDetails: () => void
   disableEditAccessCode: boolean
   disableDeleteAccessCode: boolean
@@ -53,7 +53,7 @@ function Content({
   disableEditAccessCode,
   disableDeleteAccessCode,
   onEdit,
-  onDelete,
+  onDeleteSuccess,
   deleteConfirmationVisible,
   toggleDeleteConfirmation,
 }: ContentProps): JSX.Element {
@@ -76,7 +76,7 @@ function Content({
                   access_code_id: accessCode.access_code_id,
                 },
                 {
-                  onSuccess: onDelete,
+                  onSuccess: onDeleteSuccess,
                 }
               )
             }}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -58,6 +58,7 @@ function Content({
   toggleDeleteConfirmation,
 }: ContentProps): JSX.Element {
   const deleteAccessCode = useDeleteAccessCode()
+  const isAccessCodeBeingRemoved = accessCode.status === 'removing'
 
   if (deleteConfirmationVisible) {
     return (
@@ -104,10 +105,10 @@ function Content({
       </MenuItem>
       <div className='seam-divider' />
       <MenuItem onClick={onViewDetails}>{t.viewCodeDetails}</MenuItem>
-      {!disableEditAccessCode && (
+      {(!disableEditAccessCode || !isAccessCodeBeingRemoved) && (
         <MenuItem onClick={onEdit}>{t.editCode}</MenuItem>
       )}
-      {!disableDeleteAccessCode && (
+      {(!disableDeleteAccessCode || !isAccessCodeBeingRemoved) && (
         <>
           <div className='seam-divider' />
           <MenuItem

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -105,10 +105,10 @@ function Content({
       </MenuItem>
       <div className='seam-divider' />
       <MenuItem onClick={onViewDetails}>{t.viewCodeDetails}</MenuItem>
-      {(!disableEditAccessCode || !isAccessCodeBeingRemoved) && (
+      {!disableEditAccessCode && !isAccessCodeBeingRemoved && (
         <MenuItem onClick={onEdit}>{t.editCode}</MenuItem>
       )}
-      {(!disableDeleteAccessCode || !isAccessCodeBeingRemoved) && (
+      {!disableDeleteAccessCode && !isAccessCodeBeingRemoved && (
         <>
           <div className='seam-divider' />
           <MenuItem

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeMenu.tsx
@@ -14,18 +14,31 @@ export interface AccessCodeMenuProps {
   onViewDetails: () => void
   disableEditAccessCode: boolean
   disableDeleteAccessCode: boolean
+  deleteConfirmationVisible: boolean
+  toggleDeleteConfirmation: () => void
 }
 
 export function AccessCodeMenu(props: AccessCodeMenuProps): JSX.Element {
+  const [deleteConfirmationVisible, toggleDeleteConfirmation] = useToggle()
+
   return (
     <MoreActionsMenu
       menuProps={{
         backgroundProps: {
           className: 'seam-table-action-menu',
         },
+        onClose: () => {
+          if (deleteConfirmationVisible) {
+            toggleDeleteConfirmation()
+          }
+        },
       }}
     >
-      <Content {...props} />
+      <Content
+        {...props}
+        deleteConfirmationVisible={deleteConfirmationVisible}
+        toggleDeleteConfirmation={toggleDeleteConfirmation}
+      />
     </MoreActionsMenu>
   )
 }
@@ -36,9 +49,9 @@ function Content({
   disableEditAccessCode,
   disableDeleteAccessCode,
   onEdit,
+  deleteConfirmationVisible,
+  toggleDeleteConfirmation,
 }: AccessCodeMenuProps): JSX.Element {
-  const [deleteConfirmationVisible, toggleDeleteConfirmation] = useToggle()
-
   const deleteAccessCode = useDeleteAccessCode()
 
   if (deleteConfirmationVisible) {
@@ -46,10 +59,7 @@ function Content({
       <div className='seam-delete-confirmation'>
         <span>{t.deleteCodeConfirmation}</span>
         <div className='seam-actions'>
-          <Button
-            onClick={toggleDeleteConfirmation}
-            disabled={deleteAccessCode.isPending}
-          >
+          <Button disabled={deleteAccessCode.isPending}>
             {t.cancelDelete}
           </Button>
           <Button

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
@@ -13,6 +13,7 @@ export interface AccessCodeRowProps {
   accessCode: AccessCode
   onClick: () => void
   onEdit: () => void
+  onDelete: () => void
   disableEditAccessCode: boolean
   disableDeleteAccessCode: boolean
 }
@@ -21,25 +22,39 @@ export function AccessCodeRow({
   onClick,
   accessCode,
   onEdit,
+  onDelete,
   disableEditAccessCode,
   disableDeleteAccessCode,
 }: AccessCodeRowProps): JSX.Element {
+  const isBeingRemoved = accessCode.status === 'removing'
+
   const errorCount = accessCode.errors.length
-  const warningCount = accessCode.warnings.length
-  const isPlural = errorCount === 0 || errorCount > 1
-  const errorIconTitle = isPlural
-    ? `${errorCount} ${t.codeIssues}`
-    : `${errorCount} ${t.codeIssue}`
-  const warningIconTitle = isPlural
-    ? `${warningCount} ${t.codeIssues}`
-    : `${warningCount} ${t.codeIssue}`
+  const warningCount = accessCode.warnings.length + (isBeingRemoved ? 1 : 0)
+  const errorIconTitle =
+    errorCount === 0 || errorCount > 1
+      ? `${errorCount} ${t.codeIssues}`
+      : `${errorCount} ${t.codeIssue}`
+  const warningIconTitle =
+    warningCount === 0 || warningCount > 1
+      ? `${warningCount} ${t.codeIssues}`
+      : `${warningCount} ${t.codeIssue}`
 
   return (
     <TableRow onClick={onClick}>
-      <TableCell className='seam-icon-cell'>
+      <TableCell
+        className='seam-icon-cell'
+        style={{
+          opacity: isBeingRemoved ? 0.4 : 1,
+        }}
+      >
         <AccessCodeMainIcon accessCode={accessCode} />
       </TableCell>
-      <TableCell className='seam-name-cell'>
+      <TableCell
+        className='seam-name-cell'
+        style={{
+          opacity: isBeingRemoved ? 0.4 : 1,
+        }}
+      >
         <Title className='seam-truncated-text'>{accessCode.name}</Title>
         <CodeDetails accessCode={accessCode} />
       </TableCell>
@@ -63,9 +78,10 @@ export function AccessCodeRow({
         <AccessCodeMenu
           accessCode={accessCode}
           onEdit={onEdit}
+          onDelete={onDelete}
           onViewDetails={onClick}
-          disableDeleteAccessCode={disableDeleteAccessCode}
-          disableEditAccessCode={disableEditAccessCode}
+          disableDeleteAccessCode={isBeingRemoved || disableDeleteAccessCode}
+          disableEditAccessCode={isBeingRemoved || disableEditAccessCode}
         />
       </TableCell>
     </TableRow>

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
@@ -79,12 +79,8 @@ export function AccessCodeRow({
           onEdit={onEdit}
           onDeleteSuccess={onDeleteSuccess}
           onViewDetails={onClick}
-          disableDeleteAccessCode={
-            isAccessCodeBeingRemoved || disableDeleteAccessCode
-          }
-          disableEditAccessCode={
-            isAccessCodeBeingRemoved || disableEditAccessCode
-          }
+          disableDeleteAccessCode={disableDeleteAccessCode}
+          disableEditAccessCode={disableEditAccessCode}
         />
       </TableCell>
     </TableRow>

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
@@ -14,7 +14,7 @@ export interface AccessCodeRowProps {
   accessCode: AccessCode
   onClick: () => void
   onEdit: () => void
-  onDelete: () => void
+  onDeleteSuccess: () => void
   disableEditAccessCode: boolean
   disableDeleteAccessCode: boolean
 }
@@ -23,7 +23,7 @@ export function AccessCodeRow({
   onClick,
   accessCode,
   onEdit,
-  onDelete,
+  onDeleteSuccess,
   disableEditAccessCode,
   disableDeleteAccessCode,
 }: AccessCodeRowProps): JSX.Element {
@@ -77,7 +77,7 @@ export function AccessCodeRow({
         <AccessCodeMenu
           accessCode={accessCode}
           onEdit={onEdit}
-          onDelete={onDelete}
+          onDeleteSuccess={onDeleteSuccess}
           onViewDetails={onClick}
           disableDeleteAccessCode={
             isAccessCodeBeingRemoved || disableDeleteAccessCode

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
@@ -30,8 +30,7 @@ export function AccessCodeRow({
   const isAccessCodeBeingRemoved = accessCode.status === 'removing'
 
   const errorCount = accessCode.errors.length
-  const warningCount =
-    accessCode.warnings.length + (isAccessCodeBeingRemoved ? 1 : 0)
+  const warningCount = accessCode.warnings.length
   const errorIconTitle =
     errorCount === 0 || errorCount > 1
       ? `${errorCount} ${t.codeIssues}`

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
@@ -26,10 +26,11 @@ export function AccessCodeRow({
   disableEditAccessCode,
   disableDeleteAccessCode,
 }: AccessCodeRowProps): JSX.Element {
-  const isBeingRemoved = accessCode.status === 'removing'
+  const isAccessCodeBeingRemoved = accessCode.status === 'removing'
 
   const errorCount = accessCode.errors.length
-  const warningCount = accessCode.warnings.length + (isBeingRemoved ? 1 : 0)
+  const warningCount =
+    accessCode.warnings.length + (isAccessCodeBeingRemoved ? 1 : 0)
   const errorIconTitle =
     errorCount === 0 || errorCount > 1
       ? `${errorCount} ${t.codeIssues}`
@@ -44,7 +45,7 @@ export function AccessCodeRow({
       <TableCell
         className='seam-icon-cell'
         style={{
-          opacity: isBeingRemoved ? 0.4 : 1,
+          opacity: isAccessCodeBeingRemoved ? 0.4 : 1,
         }}
       >
         <AccessCodeMainIcon accessCode={accessCode} />
@@ -52,7 +53,7 @@ export function AccessCodeRow({
       <TableCell
         className='seam-name-cell'
         style={{
-          opacity: isBeingRemoved ? 0.4 : 1,
+          opacity: isAccessCodeBeingRemoved ? 0.4 : 1,
         }}
       >
         <Title className='seam-truncated-text'>{accessCode.name}</Title>
@@ -80,8 +81,12 @@ export function AccessCodeRow({
           onEdit={onEdit}
           onDelete={onDelete}
           onViewDetails={onClick}
-          disableDeleteAccessCode={isBeingRemoved || disableDeleteAccessCode}
-          disableEditAccessCode={isBeingRemoved || disableEditAccessCode}
+          disableDeleteAccessCode={
+            isAccessCodeBeingRemoved || disableDeleteAccessCode
+          }
+          disableEditAccessCode={
+            isAccessCodeBeingRemoved || disableEditAccessCode
+          }
         />
       </TableCell>
     </TableRow>

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeRow.tsx
@@ -1,4 +1,5 @@
 import type { AccessCode } from '@seamapi/types/connect'
+import classNames from 'classnames'
 
 import { ExclamationCircleOutlineIcon } from 'lib/icons/ExclamationCircleOutline.js'
 import { TriangleWarningOutlineIcon } from 'lib/icons/TriangleWarningOutline.js'
@@ -43,18 +44,16 @@ export function AccessCodeRow({
   return (
     <TableRow onClick={onClick}>
       <TableCell
-        className='seam-icon-cell'
-        style={{
-          opacity: isAccessCodeBeingRemoved ? 0.4 : 1,
-        }}
+        className={classNames('seam-icon-cell', {
+          'seam-grayed-out': isAccessCodeBeingRemoved,
+        })}
       >
         <AccessCodeMainIcon accessCode={accessCode} />
       </TableCell>
       <TableCell
-        className='seam-name-cell'
-        style={{
-          opacity: isAccessCodeBeingRemoved ? 0.4 : 1,
-        }}
+        className={classNames('seam-name-cell', {
+          'seam-grayed-out': isAccessCodeBeingRemoved,
+        })}
       >
         <Title className='seam-truncated-text'>{accessCode.name}</Title>
         <CodeDetails accessCode={accessCode} />

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -112,7 +112,7 @@ export function AccessCodeTable({
     [setSelectedEditAccessCodeId]
   )
 
-  const handleAccessCodeDelete = useCallback((): void => {
+  const handleAccessCodeDeleteSuccess = useCallback((): void => {
     setAccessCodeResult('deleted')
   }, [])
 
@@ -169,7 +169,7 @@ export function AccessCodeTable({
             setSelectedEditAccessCodeId(selectedViewAccessCodeId)
           }}
           onDeleteSuccess={() => {
-            handleAccessCodeDelete()
+            handleAccessCodeDeleteSuccess()
           }}
           errorFilter={errorFilter}
           warningFilter={warningFilter}
@@ -264,7 +264,7 @@ export function AccessCodeTable({
             accessCodes={filteredAccessCodes}
             onAccessCodeClick={handleAccessCodeClick}
             onAccessCodeEdit={handleAccessCodeEdit}
-            onAccessCodeDelete={handleAccessCodeDelete}
+            onAccessCodeDeleteSuccess={handleAccessCodeDeleteSuccess}
             errorFilter={errorFilter}
             warningFilter={warningFilter}
             disableEditAccessCode={disableEditAccessCode}
@@ -293,7 +293,7 @@ function Content(props: {
   accessCodes: AccessCode[]
   onAccessCodeClick: (accessCodeId: string) => void
   onAccessCodeEdit: (accessCodeId: string) => void
-  onAccessCodeDelete: (accessCodeId: string) => void
+  onAccessCodeDeleteSuccess: (accessCodeId: string) => void
   errorFilter: (error: AccessCode['errors'][number]) => boolean
   warningFilter: (warning: AccessCode['warnings'][number]) => boolean
   disableEditAccessCode: boolean
@@ -303,7 +303,7 @@ function Content(props: {
     accessCodes,
     onAccessCodeClick,
     onAccessCodeEdit,
-    onAccessCodeDelete,
+    onAccessCodeDeleteSuccess,
     errorFilter,
     warningFilter,
     disableEditAccessCode,
@@ -351,7 +351,7 @@ function Content(props: {
             onAccessCodeEdit(accessCode.access_code_id)
           }}
           onDeleteSuccess={() => {
-            onAccessCodeDelete(accessCode.access_code_id)
+            onAccessCodeDeleteSuccess(accessCode.access_code_id)
           }}
         />
       ))}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -140,14 +140,19 @@ export function AccessCodeTable({
 
   const handleAccessCodeDelete = useCallback((accessCodeId: string): void => {
     setDeletedAccessCodeIds((prev) => [...prev, accessCodeId])
+    setAccessCodeResult('deleted')
   }, [])
 
   const [accessCodeResult, setAccessCodeResult] = useState<
-    'created' | 'updated' | null
+    'created' | 'updated' | 'deleted' | null
   >(null)
 
   const accessCodeResultMessage =
-    accessCodeResult === 'created' ? t.accessCodeCreated : t.accessCodeUpdated
+    accessCodeResult === 'created'
+      ? t.accessCodeCreated
+      : accessCodeResult === 'deleted'
+        ? t.accessCodeDeleted
+        : t.accessCodeUpdated
 
   if (selectedEditAccessCodeId != null) {
     return (
@@ -392,6 +397,7 @@ const t = {
   loading: 'Loading access codes',
   accessCodeUpdated: 'Access code updated',
   accessCodeCreated: 'Access code created',
+  accessCodeDeleted: 'Access code is being removed',
   tryAgain: 'Try again',
   fallbackErrorMessage: 'Access codes could not be loaded',
 }

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -1,6 +1,6 @@
 import type { AccessCode } from '@seamapi/types/connect'
 import classNames from 'classnames'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { compareByCreatedAtDesc } from 'lib/dates.js'
 import { AddIcon } from 'lib/icons/Add.js'
@@ -60,6 +60,14 @@ const defaultAccessCodeFilter = (
     name.trim().toLowerCase().includes(value) ||
     code.trim().toLowerCase().includes(value)
   )
+}
+
+const accessCodeResultToMessage = (
+  result: 'created' | 'updated' | 'deleted' | null
+): string => {
+  if (result === 'created') return t.accessCodeCreated
+  if (result === 'deleted') return t.accessCodeDeleted
+  return t.accessCodeUpdated
 }
 
 export function AccessCodeTable({
@@ -133,13 +141,15 @@ export function AccessCodeTable({
   const [accessCodeResult, setAccessCodeResult] = useState<
     'created' | 'updated' | 'deleted' | null
   >(null)
+  const [snackbarMessage, setSnackbarMessage] = useState<string>(
+    accessCodeResultToMessage(accessCodeResult)
+  )
 
-  const accessCodeResultMessage =
-    accessCodeResult === 'created'
-      ? t.accessCodeCreated
-      : accessCodeResult === 'deleted'
-        ? t.accessCodeDeleted
-        : t.accessCodeUpdated
+  useEffect(() => {
+    if (accessCodeResult !== null) {
+      setSnackbarMessage(accessCodeResultToMessage(accessCodeResult))
+    }
+  }, [accessCodeResult])
 
   if (selectedEditAccessCodeId != null) {
     return (
@@ -170,7 +180,7 @@ export function AccessCodeTable({
       <>
         <Snackbar
           variant='success'
-          message={accessCodeResultMessage}
+          message={snackbarMessage}
           visible={accessCodeResult != null}
           autoDismiss
           onClose={() => {
@@ -231,7 +241,7 @@ export function AccessCodeTable({
     <>
       <Snackbar
         variant='success'
-        message={accessCodeResultMessage}
+        message={snackbarMessage}
         visible={accessCodeResult != null}
         autoDismiss
         onClose={() => {

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -48,28 +48,6 @@ export interface AccessCodeTableProps extends CommonProps {
   heading?: string | null
 }
 
-const defaultAccessCodeFilter = (
-  accessCode: AccessCode,
-  searchInputValue: string
-): boolean => {
-  const value = searchInputValue.trim().toLowerCase()
-  if (value === '') return true
-  const name = accessCode.name ?? ''
-  const code = accessCode.code ?? ''
-  return (
-    name.trim().toLowerCase().includes(value) ||
-    code.trim().toLowerCase().includes(value)
-  )
-}
-
-const accessCodeResultToMessage = (
-  result: 'created' | 'updated' | 'deleted'
-): string => {
-  if (result === 'created') return t.accessCodeCreated
-  if (result === 'deleted') return t.accessCodeDeleted
-  return t.accessCodeUpdated
-}
-
 export function AccessCodeTable({
   deviceId,
   disableSearch = false,
@@ -379,6 +357,28 @@ function Content(props: {
       ))}
     </>
   )
+}
+
+const defaultAccessCodeFilter = (
+  accessCode: AccessCode,
+  searchInputValue: string
+): boolean => {
+  const value = searchInputValue.trim().toLowerCase()
+  if (value === '') return true
+  const name = accessCode.name ?? ''
+  const code = accessCode.code ?? ''
+  return (
+    name.trim().toLowerCase().includes(value) ||
+    code.trim().toLowerCase().includes(value)
+  )
+}
+
+const accessCodeResultToMessage = (
+  result: 'created' | 'updated' | 'deleted'
+): string => {
+  if (result === 'created') return t.accessCodeCreated
+  if (result === 'deleted') return t.accessCodeDeleted
+  return t.accessCodeUpdated
 }
 
 const t = {

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -112,14 +112,14 @@ export function AccessCodeTable({
     [setSelectedEditAccessCodeId]
   )
 
-  const handleAccessCodeDeleteSuccess = useCallback((): void => {
-    setAccessCodeResult('deleted')
-  }, [])
-
   const [accessCodeResult, setAccessCodeResult] = useState<
     'created' | 'updated' | 'deleted' | null
   >(null)
   const [snackbarMessage, setSnackbarMessage] = useState<string>('')
+
+  const handleAccessCodeDeleteSuccess = useCallback((): void => {
+    setAccessCodeResult('deleted')
+  }, [setAccessCodeResult])
 
   // Circumvent Snackbar bug that causes it to switch to default message
   // while the dismiss animation is playing

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -209,11 +209,13 @@ export function AccessCodeTable({
             disableConnectedAccountInformation
           }
           disableClimateSettingSchedules={disableClimateSettingSchedules}
-          isAccessCodeBeingRemoved={filteredAccessCodes.some(
-            (accessCode) =>
-              accessCode.access_code_id === selectedViewAccessCodeId &&
-              accessCode.status === 'removing'
-          )}
+          isAccessCodeBeingRemoved={
+            !filteredAccessCodes.some(
+              (accessCode) =>
+                accessCode.access_code_id === selectedViewAccessCodeId &&
+                accessCode.status !== 'removing'
+            )
+          }
           onBack={() => {
             setSelectedViewAccessCodeId(null)
           }}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -165,9 +165,6 @@ export function AccessCodeTable({
         />
         <NestedAccessCodeDetails
           accessCodeId={selectedViewAccessCodeId}
-          onEdit={() => {
-            setSelectedEditAccessCodeId(selectedViewAccessCodeId)
-          }}
           onDeleteSuccess={() => {
             handleAccessCodeDeleteSuccess()
           }}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -63,7 +63,7 @@ const defaultAccessCodeFilter = (
 }
 
 const accessCodeResultToMessage = (
-  result: 'created' | 'updated' | 'deleted' | null
+  result: 'created' | 'updated' | 'deleted'
 ): string => {
   if (result === 'created') return t.accessCodeCreated
   if (result === 'deleted') return t.accessCodeDeleted
@@ -141,9 +141,7 @@ export function AccessCodeTable({
   const [accessCodeResult, setAccessCodeResult] = useState<
     'created' | 'updated' | 'deleted' | null
   >(null)
-  const [snackbarMessage, setSnackbarMessage] = useState<string>(
-    accessCodeResultToMessage(accessCodeResult)
-  )
+  const [snackbarMessage, setSnackbarMessage] = useState<string>('')
 
   useEffect(() => {
     if (accessCodeResult !== null) {

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -105,7 +105,7 @@ export function AccessCodeTable({
         ?.filter((accessCode) => accessCodeFilter(accessCode, searchInputValue))
         ?.map((accessCode) =>
           deletedAccessCodeIds.includes(accessCode.access_code_id)
-            ? { ...accessCode, status: 'removing' }
+            ? { ...accessCode, status: 'removing' as const }
             : accessCode
         )
         ?.sort(accessCodeComparator) ?? [],

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -87,7 +87,6 @@ export function AccessCodeTable({
   const { accessCodes, isInitialLoading, isError, refetch } = useAccessCodes({
     device_id: deviceId,
   })
-  const [deletedAccessCodeIds, setDeletedAccessCodeIds] = useState<string[]>([])
 
   const [selectedViewAccessCodeId, setSelectedViewAccessCodeId] = useState<
     string | null
@@ -103,19 +102,8 @@ export function AccessCodeTable({
     () =>
       accessCodes
         ?.filter((accessCode) => accessCodeFilter(accessCode, searchInputValue))
-        ?.map((accessCode) =>
-          deletedAccessCodeIds.includes(accessCode.access_code_id)
-            ? { ...accessCode, status: 'removing' as const }
-            : accessCode
-        )
         ?.sort(accessCodeComparator) ?? [],
-    [
-      accessCodes,
-      searchInputValue,
-      accessCodeFilter,
-      accessCodeComparator,
-      deletedAccessCodeIds,
-    ]
+    [accessCodes, searchInputValue, accessCodeFilter, accessCodeComparator]
   )
 
   const handleAccessCodeClick = useCallback(
@@ -138,8 +126,7 @@ export function AccessCodeTable({
     [setSelectedEditAccessCodeId]
   )
 
-  const handleAccessCodeDelete = useCallback((accessCodeId: string): void => {
-    setDeletedAccessCodeIds((prev) => [...prev, accessCodeId])
+  const handleAccessCodeDelete = useCallback((): void => {
     setAccessCodeResult('deleted')
   }, [])
 
@@ -196,7 +183,7 @@ export function AccessCodeTable({
             setSelectedEditAccessCodeId(selectedViewAccessCodeId)
           }}
           onDelete={() => {
-            handleAccessCodeDelete(selectedViewAccessCodeId)
+            handleAccessCodeDelete()
           }}
           errorFilter={errorFilter}
           warningFilter={warningFilter}
@@ -209,13 +196,6 @@ export function AccessCodeTable({
             disableConnectedAccountInformation
           }
           disableClimateSettingSchedules={disableClimateSettingSchedules}
-          isAccessCodeBeingRemoved={
-            !filteredAccessCodes.some(
-              (accessCode) =>
-                accessCode.access_code_id === selectedViewAccessCodeId &&
-                accessCode.status !== 'removing'
-            )
-          }
           onBack={() => {
             setSelectedViewAccessCodeId(null)
           }}

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -121,6 +121,8 @@ export function AccessCodeTable({
   >(null)
   const [snackbarMessage, setSnackbarMessage] = useState<string>('')
 
+  // Circumvent Snackbar bug that causes it to switch to default message
+  // while the dismiss animation is playing
   useEffect(() => {
     if (accessCodeResult !== null) {
       setSnackbarMessage(accessCodeResultToMessage(accessCodeResult))
@@ -153,38 +155,22 @@ export function AccessCodeTable({
 
   if (selectedViewAccessCodeId != null) {
     return (
-      <>
-        <Snackbar
-          variant='success'
-          message={snackbarMessage}
-          visible={accessCodeResult != null}
-          autoDismiss
-          onClose={() => {
-            setAccessCodeResult(null)
-          }}
-        />
-        <NestedAccessCodeDetails
-          accessCodeId={selectedViewAccessCodeId}
-          onDeleteSuccess={() => {
-            handleAccessCodeDeleteSuccess()
-          }}
-          errorFilter={errorFilter}
-          warningFilter={warningFilter}
-          disableLockUnlock={disableLockUnlock}
-          disableCreateAccessCode={disableCreateAccessCode}
-          disableEditAccessCode={disableEditAccessCode}
-          disableDeleteAccessCode={disableDeleteAccessCode}
-          disableResourceIds={disableResourceIds}
-          disableConnectedAccountInformation={
-            disableConnectedAccountInformation
-          }
-          disableClimateSettingSchedules={disableClimateSettingSchedules}
-          onBack={() => {
-            setSelectedViewAccessCodeId(null)
-          }}
-          className={className}
-        />
-      </>
+      <NestedAccessCodeDetails
+        accessCodeId={selectedViewAccessCodeId}
+        errorFilter={errorFilter}
+        warningFilter={warningFilter}
+        disableLockUnlock={disableLockUnlock}
+        disableCreateAccessCode={disableCreateAccessCode}
+        disableEditAccessCode={disableEditAccessCode}
+        disableDeleteAccessCode={disableDeleteAccessCode}
+        disableResourceIds={disableResourceIds}
+        disableConnectedAccountInformation={disableConnectedAccountInformation}
+        disableClimateSettingSchedules={disableClimateSettingSchedules}
+        onBack={() => {
+          setSelectedViewAccessCodeId(null)
+        }}
+        className={className}
+      />
     )
   }
 

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -204,7 +204,7 @@ export function AccessCodeTable({
             disableConnectedAccountInformation
           }
           disableClimateSettingSchedules={disableClimateSettingSchedules}
-          isBeingRemoved={filteredAccessCodes.some(
+          isAccessCodeBeingRemoved={filteredAccessCodes.some(
             (accessCode) =>
               accessCode.access_code_id === selectedViewAccessCodeId &&
               accessCode.status === 'removing'

--- a/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
+++ b/src/lib/seam/components/AccessCodeTable/AccessCodeTable.tsx
@@ -182,7 +182,7 @@ export function AccessCodeTable({
           onEdit={() => {
             setSelectedEditAccessCodeId(selectedViewAccessCodeId)
           }}
-          onDelete={() => {
+          onDeleteSuccess={() => {
             handleAccessCodeDelete()
           }}
           errorFilter={errorFilter}
@@ -364,7 +364,7 @@ function Content(props: {
           onEdit={() => {
             onAccessCodeEdit(accessCode.access_code_id)
           }}
-          onDelete={() => {
+          onDeleteSuccess={() => {
             onAccessCodeDelete(accessCode.access_code_id)
           }}
         />

--- a/src/lib/ui/Menu/Menu.tsx
+++ b/src/lib/ui/Menu/Menu.tsx
@@ -23,6 +23,7 @@ export interface MenuProps extends PropsWithChildren {
   backgroundProps?: Partial<{
     className?: string
   }>
+  onClose?: () => void
 }
 
 interface MenuContext {
@@ -40,6 +41,7 @@ export function Menu({
   children,
   renderButton,
   backgroundProps,
+  onClose,
 }: MenuProps): JSX.Element | null {
   const { Provider } = menuContext
   const [documentEl, setDocumentEl] = useState<null | HTMLElement>(null)
@@ -59,6 +61,7 @@ export function Menu({
   }, [setDocumentEl])
 
   const handleClose = (): void => {
+    onClose?.()
     setAnchorEl(null)
   }
 

--- a/src/styles/_seam-table.scss
+++ b/src/styles/_seam-table.scss
@@ -94,6 +94,10 @@
         margin-right: 8px;
       }
     }
+
+    .seam-grayed-out {
+      opacity: 0.4;
+    }
   }
 
   .seam-table-action-menu {


### PR DESCRIPTION
## Context
https://github.com/seamapi/react/issues/449
https://github.com/seamapi/react/issues/651

## Changes
### New
- Gray out access-code rows when their status is "removing"
- Show a warning in the access-code details view when the access-code's status is "removing"
- Disable edit and delete actions when access-code is in "removing" state
- Optimistically mark access-codes as "removing" when the deletion query is successful
- Show snackbar when access code is deleted
- New props to be able to control onDelete for AccessCodeDetails

### Fixes
- Fix a bug that kept a wrong state for the access-code row menu when closed (reopening it would show the deletion menu instead of the normal menu)
- Fix bug where the AccessCodeDetails was missing a nested edit form
- Circumvent bug with snackbar that causes the wrong message to be displayed temporarily


## Images
<img width="773" alt="Screenshot 2024-07-23 at 5 39 27 PM" src="https://github.com/user-attachments/assets/38e7f45e-fa3e-4565-90a6-972aa4dc8f7f">
<img width="744" alt="Screenshot 2024-07-23 at 5 39 43 PM" src="https://github.com/user-attachments/assets/01cb6c7c-5c4a-4188-b295-a9b7e311c09a">
