### PR TITLE
fix: Ensure query key is prefix by session scope

### DIFF
--- a/src/lib/seam/SeamProvider.tsx
+++ b/src/lib/seam/SeamProvider.tsx
@@ -69,6 +69,7 @@ export function SeamProvider({
   disableFontInjection = false,
   unminifiyCss = false,
   telemetryClient,
+  queryClient,
   ...props
 }: SeamProviderProps): JSX.Element {
   useSeamStyles({ disabled: disableCssInjection, unminified: unminifiyCss })
@@ -89,7 +90,10 @@ export function SeamProvider({
         disabled={disableTelemetry}
         endpoint={endpoint}
       >
-        <SeamQueryProvider {...props}>
+        <SeamQueryProvider
+          queryClient={queryClient ?? globalThis.seamQueryClient}
+          {...props}
+        >
           <Provider value={value}>
             <Telemetry>{children}</Telemetry>
           </Provider>

--- a/src/lib/seam/SeamQueryProvider.tsx
+++ b/src/lib/seam/SeamQueryProvider.tsx
@@ -3,7 +3,11 @@ import type {
   SeamHttpEndpoints,
   SeamHttpOptionsWithClientSessionToken,
 } from '@seamapi/http/connect'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  QueryClient,
+  QueryClientContext,
+  QueryClientProvider,
+} from '@tanstack/react-query'
 import {
   createContext,
   type PropsWithChildren,
@@ -88,9 +92,22 @@ export function SeamQueryProvider({
   }
 
   const { Provider } = seamContext
+  const queryClientFromContext = useContext(QueryClientContext)
+
+  if (
+    queryClientFromContext != null &&
+    queryClient != null &&
+    queryClientFromContext !== queryClient
+  ) {
+    throw new Error(
+      'The QueryClient passed into SeamQueryProvider is different from the one in the existing QueryClientContext. Omit the queryClient prop from SeamProvider or SeamQueryProvider to use the existing QueryClient provided by the QueryClientProvider.'
+    )
+  }
 
   return (
-    <QueryClientProvider client={queryClient ?? defaultQueryClient}>
+    <QueryClientProvider
+      client={queryClientFromContext ?? queryClient ?? defaultQueryClient}
+    >
       <Provider value={value}>
         <Session onSessionUpdate={onSessionUpdate}>{children}</Session>
       </Provider>

--- a/src/lib/seam/SeamQueryProvider.tsx
+++ b/src/lib/seam/SeamQueryProvider.tsx
@@ -21,6 +21,7 @@ export interface SeamQueryContext {
   publishableKey?: string | undefined
   userIdentifierKey?: string | undefined
   clientSessionToken?: string | undefined
+  queryKeyPrefix?: string | undefined
 }
 
 export type SeamQueryProviderProps =
@@ -31,6 +32,7 @@ export type SeamQueryProviderProps =
 export interface SeamQueryProviderPropsWithClient
   extends SeamQueryProviderBaseProps {
   client: SeamHttp
+  queryKeyPrefix: string
 }
 
 export interface SeamQueryProviderPropsWithPublishableKey
@@ -126,6 +128,11 @@ const createSeamQueryContextValue = (
   options: SeamQueryProviderProps
 ): SeamQueryContext => {
   if (isSeamQueryProviderPropsWithClient(options)) {
+    if (options.queryKeyPrefix == null) {
+      throw new InvalidSeamQueryProviderProps(
+        'The client prop must be used with a queryKeyPrefix prop.'
+      )
+    }
     return {
       ...options,
       endpointClient: null,

--- a/src/lib/seam/SeamQueryProvider.tsx
+++ b/src/lib/seam/SeamQueryProvider.tsx
@@ -88,9 +88,7 @@ export function SeamQueryProvider({
   const { Provider } = seamContext
 
   return (
-    <QueryClientProvider
-      client={queryClient ?? globalThis.seamQueryClient ?? defaultQueryClient}
-    >
+    <QueryClientProvider client={queryClient ?? defaultQueryClient}>
       <Provider value={value}>
         <Session onSessionUpdate={onSessionUpdate}>{children}</Session>
       </Provider>

--- a/src/lib/seam/use-seam-client.ts
+++ b/src/lib/seam/use-seam-client.ts
@@ -8,6 +8,7 @@ import { useSeamQueryContext } from './SeamQueryProvider.js'
 export function useSeamClient(): {
   client: SeamHttp | null
   endpointClient: SeamHttpEndpoints | null
+  queryKeyPrefix: string[]
   isPending: boolean
   isError: boolean
   error: unknown
@@ -17,6 +18,7 @@ export function useSeamClient(): {
     clientOptions,
     publishableKey,
     clientSessionToken,
+    queryKeyPrefix,
     ...context
   } = useSeamQueryContext()
   const userIdentifierKey = useUserIdentifierKeyOrFingerprint(
@@ -27,6 +29,7 @@ export function useSeamClient(): {
     [SeamHttp, SeamHttpEndpoints]
   >({
     queryKey: [
+      'seam',
       'client',
       {
         client,
@@ -73,6 +76,15 @@ export function useSeamClient(): {
   return {
     client: data?.[0] ?? null,
     endpointClient: data?.[1] ?? null,
+    queryKeyPrefix: [
+      'seam',
+      queryKeyPrefix ??
+        getQueryKeyPrefix({
+          userIdentifierKey,
+          publishableKey,
+          clientSessionToken,
+        }),
+    ],
     isPending,
     isError,
     error,
@@ -116,4 +128,24 @@ This is not recommended because the client session is now bound to this machine 
   globalThis.localStorage?.setItem('seam_user_fingerprint', fingerprint)
 
   return fingerprint
+}
+
+const getQueryKeyPrefix = ({
+  userIdentifierKey,
+  publishableKey,
+  clientSessionToken,
+}: {
+  userIdentifierKey: string
+  publishableKey: string | undefined
+  clientSessionToken: string | undefined
+}): string => {
+  if (clientSessionToken != null) {
+    return clientSessionToken
+  }
+
+  if (publishableKey != null) {
+    return [publishableKey, userIdentifierKey].join(':')
+  }
+
+  throw new Error('Could not determine a queryKeyPrefix')
 }

--- a/src/lib/seam/use-seam-query.ts
+++ b/src/lib/seam/use-seam-query.ts
@@ -23,11 +23,15 @@ export function useSeamQuery<T extends SeamHttpEndpointQueryPaths>(
   options: Parameters<SeamHttpEndpoints[T]>[1] &
     QueryOptions<QueryData<T>, SeamHttpApiError> = {}
 ): UseSeamQueryResult<T> {
-  const { endpointClient: client } = useSeamClient()
+  const { endpointClient: client, queryKeyPrefix } = useSeamClient()
   return useQuery({
     enabled: client != null,
     ...options,
-    queryKey: [endpointPath, parameters],
+    queryKey: [
+      ...queryKeyPrefix,
+      ...endpointPath.split('/').filter((v) => v !== ''),
+      parameters,
+    ],
     queryFn: async () => {
       if (client == null) return null
       // Using @ts-expect-error over any is preferred, but not possible here because TypeScript will run out of memory.

--- a/src/lib/seam/use-seam-query.ts
+++ b/src/lib/seam/use-seam-query.ts
@@ -23,12 +23,12 @@ export function useSeamQuery<T extends SeamHttpEndpointQueryPaths>(
   options: Parameters<SeamHttpEndpoints[T]>[1] &
     QueryOptions<QueryData<T>, SeamHttpApiError> = {}
 ): UseSeamQueryResult<T> {
-  const { endpointClient: client, queryKeyPrefix } = useSeamClient()
+  const { endpointClient: client, queryKeyPrefixes } = useSeamClient()
   return useQuery({
     enabled: client != null,
     ...options,
     queryKey: [
-      ...queryKeyPrefix,
+      ...queryKeyPrefixes,
       ...endpointPath.split('/').filter((v) => v !== ''),
       parameters,
     ],


### PR DESCRIPTION
- **Pass globalThis.seamQueryClient from SeamProvider**
- **fix: Ensure query key is prefix by session scope**
