### PR TITLE
fix: device lock status disappearing when unlocked

### DIFF
--- a/src/lib/seam/components/DeviceDetails/LockDeviceDetails.tsx
+++ b/src/lib/seam/components/DeviceDetails/LockDeviceDetails.tsx
@@ -163,7 +163,7 @@ export function LockDeviceDetails({
           </div>
 
           <div className='seam-box'>
-            {device.properties.locked && device.properties.online && (
+            {device.properties.online && (
               <div className='seam-content seam-lock-status'>
                 <div>
                   <span className='seam-label'>{t.lockStatus}</span>


### PR DESCRIPTION
Closes https://linear.app/seam/issue/CX-450/status-field-disappears-when-clicking-unlock-button-in-seam-components